### PR TITLE
refactor(logger)!: change Level type from int8 to string

### DIFF
--- a/logger/level.go
+++ b/logger/level.go
@@ -1,28 +1,56 @@
 package logger
 
+import "github.com/rs/zerolog"
+
 // Level type
-type Level int8
+type Level string
 
 const (
 	// DebugLevel defines debug log level.
-	DebugLevel Level = iota
+	DebugLevel Level = "debug"
 	// InfoLevel defines info log level.
-	InfoLevel
+	InfoLevel Level = "info"
 	// WarnLevel defines warn log level.
-	WarnLevel
+	WarnLevel Level = "warn"
 	// ErrorLevel defines error log level.
-	ErrorLevel
+	ErrorLevel Level = "error"
 	// FatalLevel defines fatal log level.
-	FatalLevel
+	FatalLevel Level = "fatal"
 	// PanicLevel defines panic log level.
-	PanicLevel
+	PanicLevel Level = "panic"
 	// NoLevel defines an absent log level.
-	NoLevel
+	NoLevel Level = "no"
 	// Disabled disables the logger.
-	Disabled
+	Disabled Level = "disabled"
 	// TraceLevel defines trace log level.
-	TraceLevel Level = -1
+	TraceLevel Level = "trace"
 )
+
+func (l Level) ZerologLevel() zerolog.Level {
+	switch l {
+	case DebugLevel:
+		return zerolog.DebugLevel
+	case InfoLevel:
+		return zerolog.InfoLevel
+	case WarnLevel:
+		return zerolog.WarnLevel
+	case ErrorLevel:
+		return zerolog.ErrorLevel
+	case FatalLevel:
+		return zerolog.FatalLevel
+	case PanicLevel:
+		return zerolog.PanicLevel
+	case NoLevel:
+		return zerolog.NoLevel
+	case Disabled:
+		return zerolog.Disabled
+	case TraceLevel:
+		return zerolog.TraceLevel
+	default:
+		// default to trace level
+		return zerolog.TraceLevel
+	}
+}
 
 var (
 	// DefaultLogLevel log level

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -142,13 +142,7 @@ func newLogger(cfg Config, traceID ...string) Logger {
 		c = c.Str(TraceID, trace)
 	}
 
-	// TODO: Consider using pointer type or string type for Level to distinguish
-	// between unset (nil) and explicitly set to 0 (DebugLevel).
-	// Current implementation using int8 cannot differentiate between:
-	// 1. Level not being set (should be nil)
-	// 2. Level explicitly set to 0 (DebugLevel).
-	// This could lead to ambiguity in log level configuration.
-	l := c.Logger().Level(zerolog.Level(cfg.LogLevel))
+	l := c.Logger().Level(cfg.LogLevel.ZerologLevel())
 
 	log := &Log{log: &l, traceID: trace}
 
@@ -260,7 +254,7 @@ func (l *Log) WithError(err error) Logger {
 
 // SetLevel set level
 func (l *Log) SetLevel(level Level) Logger {
-	zl := l.log.Level(zerolog.Level(DefaultLogLevel))
+	zl := l.log.Level(level.ZerologLevel())
 	return &Log{
 		log:     &zl,
 		traceID: l.traceID,


### PR DESCRIPTION
BREAKING CHANGE: Level type has been changed from int8 to string. This change affects all code that uses the Level type directly.

- Convert Level type from int8 to string for better readability
- Add ZerologLevel() method to map string levels to zerolog.Level
- Update logger implementation to use new Level type
- Improve type safety and maintainability