### PR TITLE
feat(validator)!: remove custom tag name binding

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -42,7 +42,6 @@ func (v *DefaultValidator) Engine() any {
 func (v *DefaultValidator) lazyinit() {
 	v.once.Do(func() {
 		v.validate = validator.New()
-		v.validate.SetTagName("binding")
 
 		// add any custom validations etc. here
 	})


### PR DESCRIPTION
BREAKING CHANGE: remove validator tag name binding This change removes the explicit setting of validator tag name to "binding". Applications using this validator will need to update their validation tags accordingly.