### PR TITLE
fix(context): implement the context.Context safely

### DIFF
--- a/binding_test.go
+++ b/binding_test.go
@@ -57,6 +57,7 @@ func TestBinding(t *testing.T) {
 		Context: &gin.Context{
 			Request: req,
 		},
+		Request: req,
 	}
 
 	ctx.Set("auth_info", &AuthInfo{Username: "binder"})
@@ -101,6 +102,7 @@ func TestBindingJSON(t *testing.T) {
 		Context: &gin.Context{
 			Request: req,
 		},
+		Request: req,
 	}
 
 	err := bind(ctx, &obj)
@@ -122,6 +124,7 @@ func TestBindingJSON(t *testing.T) {
 		Context: &gin.Context{
 			Request: req,
 		},
+		Request: req,
 	}
 
 	err = bind(ctx, &obj)
@@ -158,6 +161,7 @@ func TestIsValider(t *testing.T) {
 		Context: &gin.Context{
 			Request: req,
 		},
+		Request: req,
 	}
 
 	err := bind(ctx, &CreateUserArgs{})

--- a/context.go
+++ b/context.go
@@ -3,6 +3,8 @@ package fox
 import (
 	"bytes"
 	"io"
+	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -15,6 +17,8 @@ type Context struct {
 
 	engine *Engine
 	Logger logger.Logger
+	// Request is the http request copy from gin.Context.
+	Request *http.Request
 }
 
 // RequestBody return request body bytes
@@ -63,4 +67,25 @@ func (c *Context) TraceID() string {
 	c.Set(logger.TraceID, id)
 
 	return id
+}
+
+func (c *Context) Done() <-chan struct{} {
+	return c.Request.Context().Done()
+}
+
+func (c *Context) Err() error {
+	return c.Request.Context().Err()
+}
+
+func (c *Context) Value(key any) any {
+	return c.Request.Context().Value(key)
+}
+
+func (c *Context) Deadline() (deadline time.Time, ok bool) {
+	return c.Request.Context().Deadline()
+}
+
+func (c *Context) Next() {
+	c.Context.Request = c.Request
+	c.Context.Next()
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -355,6 +355,14 @@ func TestDefaultEnableContextWithFallback(t *testing.T) {
 			c.String(200, "no context value")
 		}
 	})
+	router.GET("/testGin", func(c *fox.Context) {
+		val := c.Context.Value(ctxKey{})
+		if val != nil {
+			c.String(200, val.(string))
+		} else {
+			c.String(200, "no context value")
+		}
+	})
 
 	t.Run("default with context value", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -369,7 +377,7 @@ func TestDefaultEnableContextWithFallback(t *testing.T) {
 		router.ContextWithFallback = false
 
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req := httptest.NewRequest(http.MethodGet, "/testGin", nil)
 		router.ServeHTTP(w, req)
 
 		assert.Equal(200, w.Code)

--- a/routergroup.go
+++ b/routergroup.go
@@ -60,6 +60,7 @@ func (group *RouterGroup) handleWrapper(handlers ...HandlerFunc) gin.HandlersCha
 						Context: c,
 						engine:  group.engine,
 						Logger:  log,
+						Request: c.Request,
 					}
 					res = call(ctx, h)
 				)


### PR DESCRIPTION
在 fox.Context 中保留 http.Request 引用，通过 fox.Context.Request.Context() 实现 context.Context 接口。

解决 gin.Context.Done() 异步调用和 gin.Context 复用更新 Request 造成的 data race 问题。