### PR TITLE
修复并发执行fox.New()时造成的data race

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -104,11 +104,13 @@ type Engine struct {
 	RenderErrorFunc RenderErrorFunc
 }
 
-// New return engine instance.
-func New() *Engine {
+func init() {
 	// Change gin default validator.
 	binding.Validator = new(DefaultValidator)
+}
 
+// New return engine instance.
+func New() *Engine {
 	engine := &Engine{
 		Engine:                       gin.New(),
 		DefaultRenderErrorStatusCode: http.StatusBadRequest,


### PR DESCRIPTION
fox的New()构造函数里修改了一个全局变量，导致单测中如果使用fox时，若同时开启了单测并发，将会导致data race的问题