### PR TITLE
fix(binding): surface context value type mismatch as error

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -3,6 +3,7 @@ package fox
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -12,6 +13,11 @@ import (
 
 // ErrBindNonPointerValue is required bind pointer
 var ErrBindNonPointerValue = errors.New("can not bind to non-pointer value")
+
+// ErrBindContextTypeMismatch is returned when a value retrieved from the
+// request context via a `context:"key"` tag cannot be converted to the
+// destination field type.
+var ErrBindContextTypeMismatch = errors.New("context value type mismatch")
 
 // DefaultBinder default binder
 var DefaultBinder binding.Binding = binding.JSON
@@ -33,7 +39,8 @@ var bodyBinders = map[string]binding.BindingBody{
 	binding.MIMETOML:     binding.TOML,     // toml
 }
 
-// bind request arguments
+// bind populates obj from the request: body (per Content-Type), then any
+// `context`, `query`, `uri`, and `header` tagged fields, in that order.
 func bind(ctx *Context, obj any) error {
 	vPtr := reflect.ValueOf(obj)
 
@@ -110,13 +117,8 @@ func bind(ctx *Context, obj any) error {
 			hasHeaderField = true
 		}
 		if tag := field.Tag.Get("context"); tag != "" && tag != "-" {
-			if value, exists := ctx.Get(tag); exists {
-				if fieldValue := vPtr.Field(i); fieldValue.CanSet() {
-					// convert context value to field type and set
-					if val := reflect.ValueOf(value); val.Type().ConvertibleTo(fieldValue.Type()) {
-						fieldValue.Set(val.Convert(fieldValue.Type()))
-					}
-				}
+			if err := bindContextField(ctx, vPtr.Field(i), field.Name, tag); err != nil {
+				return err
 			}
 		}
 	}
@@ -150,6 +152,26 @@ func bind(ctx *Context, obj any) error {
 		return valider.IsValid()
 	}
 
+	return nil
+}
+
+// bindContextField copies a value stored on ctx into a struct field tagged
+// with `context:"key"`. Missing keys, unexported fields and nil values are
+// no-ops; an unconvertible stored type returns ErrBindContextTypeMismatch.
+func bindContextField(ctx *Context, fieldValue reflect.Value, fieldName, key string) error {
+	value, exists := ctx.Get(key)
+	if !exists || value == nil {
+		return nil
+	}
+	if !fieldValue.CanSet() {
+		return nil
+	}
+	val := reflect.ValueOf(value)
+	if !val.Type().ConvertibleTo(fieldValue.Type()) {
+		return fmt.Errorf("%w: key %q (%T) -> field %s (%s)",
+			ErrBindContextTypeMismatch, key, value, fieldName, fieldValue.Type())
+	}
+	fieldValue.Set(val.Convert(fieldValue.Type()))
 	return nil
 }
 

--- a/binding_test.go
+++ b/binding_test.go
@@ -548,9 +548,32 @@ func TestBind_ContextFieldNotConvertible(t *testing.T) {
 
 	var obj TestStruct
 	err := bind(ctx, &obj)
-	// Should not error, just skip the field
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBindContextTypeMismatch)
+	assert.Contains(t, err.Error(), "int_value")
+	assert.Equal(t, 0, obj.IntValue)
+}
+
+// TestBind_ContextFieldMissing verifies that a missing or nil context value
+// leaves the destination field at its zero value without raising an error.
+func TestBind_ContextFieldMissing(t *testing.T) {
+	type TestStruct struct {
+		Missing string `context:"missing_key"`
+		Nilled  string `context:"nilled_key"`
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	ctx := &Context{
+		Context: &gin.Context{Request: req},
+		Request: req,
+	}
+	ctx.Set("nilled_key", nil)
+
+	var obj TestStruct
+	err := bind(ctx, &obj)
 	require.NoError(t, err)
-	assert.Equal(t, 0, obj.IntValue) // Should remain zero value
+	assert.Empty(t, obj.Missing)
+	assert.Empty(t, obj.Nilled)
 }
 
 // TestBind_WithBindingError tests bind with body binding error


### PR DESCRIPTION
## Summary

- Add `ErrBindContextTypeMismatch`, returned by `bind` when a value retrieved from the request context via a `context:"key"` tag cannot be converted to the destination field type.
- Extract the inline context-field copy logic into a dedicated `bindContextField` helper to keep `bind` readable.
- Tighten godoc on `bind` to describe the actual resolution order (body → `context` → `query` → `uri` → `header`).

Missing keys, `nil` stored values, and unexported fields remain silent no-ops — only an explicit type mismatch surfaces an error.

## Behavior change (heads-up)

Previously, `bind` silently skipped a `context:"key"` field when the stored value's dynamic type was not convertible to the field type, leaving the field at its zero value. After this change, the same situation returns `ErrBindContextTypeMismatch` (wrapped with the offending key, source type, field name, and target type for diagnosis).

This is a behavioral break for any caller that relied on the silent skip. In practice such cases are misconfiguration bugs that were being masked, so failing fast at the binding boundary is preferable. Worth a CHANGELOG note.

## Test plan

- [x] `go test ./...` — all suites pass
- [x] `make gofmt` / `make govet` / `make golangci-lint` — clean
- [x] New test `TestBind_ContextFieldMissing` covers the missing-key and nil-value paths (still no-op)
- [x] Updated `TestBind_ContextFieldNotConvertible` asserts `errors.Is(err, ErrBindContextTypeMismatch)` and that the message includes the offending key