### PR TITLE
feat: expose route registry metadata

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"sync"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -103,6 +104,20 @@ type Engine struct {
 	DefaultRenderErrorStatusCode int
 
 	RenderErrorFunc RenderErrorFunc
+
+	handlerRoutesMu       sync.RWMutex
+	handlerRoutes         map[handlerRouteKey]RouteInfo
+	handlerRoutesDisabled bool
+}
+
+// DisableRouteRegistry stops collecting handler reflection metadata for new
+// routes. Existing entries are dropped. Use when you do not run any tooling
+// (such as openapi generation) and want to free the per-route memory.
+func (engine *Engine) DisableRouteRegistry() {
+	engine.handlerRoutesMu.Lock()
+	defer engine.handlerRoutesMu.Unlock()
+	engine.handlerRoutesDisabled = true
+	engine.handlerRoutes = nil
 }
 
 func init() {

--- a/route_registry.go
+++ b/route_registry.go
@@ -1,0 +1,77 @@
+package fox
+
+import (
+	"reflect"
+	"runtime"
+	"sort"
+)
+
+type handlerRouteKey struct {
+	Method string
+	Path   string
+}
+
+// RouteInfo preserves the original fox handler metadata for registered routes.
+// Gin only exposes the wrapped handler, so fox records the business handler at
+// route registration time for external tooling such as documentation generators.
+type RouteInfo struct {
+	Method      string
+	Path        string
+	Handler     HandlerFunc
+	HandlerType reflect.Type
+	HandlerName string
+}
+
+func (engine *Engine) registerHandlerRoute(method, path string, handlers HandlersChain) {
+	handler := handlers.Last()
+	if handler == nil {
+		return
+	}
+
+	funcValue := reflect.ValueOf(handler)
+	funcName := ""
+	if funcValue.IsValid() && funcValue.Kind() == reflect.Func {
+		if fn := runtime.FuncForPC(funcValue.Pointer()); fn != nil {
+			funcName = fn.Name()
+		}
+	}
+
+	engine.handlerRoutesMu.Lock()
+	defer engine.handlerRoutesMu.Unlock()
+
+	if engine.handlerRoutesDisabled {
+		return
+	}
+
+	if engine.handlerRoutes == nil {
+		engine.handlerRoutes = make(map[handlerRouteKey]RouteInfo)
+	}
+
+	engine.handlerRoutes[handlerRouteKey{Method: method, Path: path}] = RouteInfo{
+		Method:      method,
+		Path:        path,
+		Handler:     handler,
+		HandlerType: reflect.TypeOf(handler),
+		HandlerName: funcName,
+	}
+}
+
+// HandlerRoutes returns a stable snapshot of routes registered through fox.
+func (engine *Engine) HandlerRoutes() []RouteInfo {
+	engine.handlerRoutesMu.RLock()
+	defer engine.handlerRoutesMu.RUnlock()
+
+	routes := make([]RouteInfo, 0, len(engine.handlerRoutes))
+	for _, route := range engine.handlerRoutes {
+		routes = append(routes, route)
+	}
+
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Path == routes[j].Path {
+			return routes[i].Method < routes[j].Method
+		}
+		return routes[i].Path < routes[j].Path
+	})
+
+	return routes
+}

--- a/route_registry_test.go
+++ b/route_registry_test.go
@@ -1,0 +1,52 @@
+package fox
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func registeredRouteHandler(_ *Context) string {
+	return "ok"
+}
+
+func TestHandlerRoutesReturnsOriginalHandlerMetadata(t *testing.T) {
+	engine := New()
+	engine.GET("/health", registeredRouteHandler)
+
+	routes := engine.HandlerRoutes()
+
+	require.Len(t, routes, 1)
+	require.Equal(t, "GET", routes[0].Method)
+	require.Equal(t, "/health", routes[0].Path)
+	require.Equal(t, reflect.TypeOf(registeredRouteHandler), routes[0].HandlerType)
+	require.Contains(t, routes[0].HandlerName, "registeredRouteHandler")
+}
+
+func TestHandlerRoutesAreSortedAndCanBeDisabled(t *testing.T) {
+	engine := New()
+	engine.POST("/zeta", registeredRouteHandler)
+	engine.GET("/alpha", registeredRouteHandler)
+	engine.POST("/alpha", registeredRouteHandler)
+
+	routes := engine.HandlerRoutes()
+	require.Len(t, routes, 3)
+	require.Equal(t, "GET", routes[0].Method)
+	require.Equal(t, "/alpha", routes[0].Path)
+	require.Equal(t, "POST", routes[1].Method)
+	require.Equal(t, "/alpha", routes[1].Path)
+	require.Equal(t, "/zeta", routes[2].Path)
+
+	engine.DisableRouteRegistry()
+	require.Empty(t, engine.HandlerRoutes())
+
+	engine.GET("/later", registeredRouteHandler)
+	require.Empty(t, engine.HandlerRoutes())
+}
+
+func TestRegisterHandlerRouteIgnoresEmptyHandlerChain(t *testing.T) {
+	engine := New()
+	engine.registerHandlerRoute("GET", "/empty", nil)
+	require.Empty(t, engine.HandlerRoutes())
+}

--- a/routergroup.go
+++ b/routergroup.go
@@ -107,6 +107,7 @@ func (group *RouterGroup) Handle(httpMethod, relativePath string, handlers ...Ha
 
 	absolutePath := utils.JoinPaths(group.router.BasePath(), relativePath)
 	debugPrintRoute(group, httpMethod, absolutePath, handlers)
+	group.engine.registerHandlerRoute(httpMethod, absolutePath, handlers)
 	return group.router.Handle(httpMethod, relativePath, handlersChain...)
 }
 


### PR DESCRIPTION
## Summary
- record original Fox handler route metadata at registration time
- expose a stable HandlerRoutes snapshot for external tooling
- add DisableRouteRegistry for users that want to opt out of metadata collection

## Testing
- go test ./...