### PR TITLE
fix: align audit fixes across binding, logging, and docs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -183,7 +183,7 @@ func main() {
 $ curl -X POST http://localhost:8080/users/signup \
     -H 'content-type: application/json' \
     -d '{"username": "George", "email": "george@vandaley.com"}'
-{"code":"PASSWORD_TOO_SHORT","error":"(400): password too short"}
+{"code":"PASSWORD_TOO_SHORT","error":"(400): password too short","meta":"password too short"}
 ```
 
 ## Architecture

--- a/.github/README.md
+++ b/.github/README.md
@@ -183,7 +183,7 @@ func main() {
 $ curl -X POST http://localhost:8080/users/signup \
     -H 'content-type: application/json' \
     -d '{"username": "George", "email": "george@vandaley.com"}'
-{"code":"PASSWORD_TOO_SHORT"}
+{"code":"PASSWORD_TOO_SHORT","error":"(400): password too short"}
 ```
 
 ## Architecture
@@ -259,7 +259,8 @@ Fox adds minimal overhead to Gin's performance while providing significant devel
 
 ### Benchmark Comparison
 
-Tested on Apple M4 Pro, Go 1.25.4:
+Example run: Apple M1 Pro / macOS / Go 1.26.2 / `GIN_MODE=release` / GOMAXPROCS=8.
+Reproduce with: `make benchmark`.
 
 ```
 Routing Benchmarks:
@@ -268,6 +269,8 @@ BenchmarkEngine_ParamRoute               1,700,000     633 ns/op    1554 B/op   
 BenchmarkEngine_MultiParam               1,300,000     879 ns/op    2121 B/op    27 allocs/op
 BenchmarkEngine_WildcardRoute            1,900,000     611 ns/op    1579 B/op    20 allocs/op
 BenchmarkEngine_JSONResponse             1,600,000     732 ns/op    1767 B/op    21 allocs/op
+BenchmarkGin_Baseline_SimpleRoute       15,273,523      71 ns/op      56 B/op     1 allocs/op
+BenchmarkGin_Baseline_JSONResponse       5,003,542     290 ns/op     342 B/op     3 allocs/op
 
 Binding Benchmarks:
 BenchmarkBinding_URIParam                  900,000    1283 ns/op    2717 B/op    36 allocs/op
@@ -428,15 +431,21 @@ router.GET("/users/:id", func(ctx *fox.Context, req *GetUserRequest) (*User, err
     return findUser(req.ID)
 })
 
-// Full control: Access context and return custom status
-router.POST("/complex", func(ctx *fox.Context, req *Request) (interface{}, int, error) {
+// Full control: Access context and set custom status
+router.POST("/complex", func(ctx *fox.Context, req *Request) (interface{}, error) {
     result, err := process(req)
     if err != nil {
-        return nil, http.StatusInternalServerError, err
+        ctx.Status(http.StatusInternalServerError)
+        return nil, err
     }
-    return result, http.StatusCreated, nil
+    ctx.Status(http.StatusCreated)
+    return result, nil
 })
 ```
+
+When a Fox handler with a non-nil return value is used as middleware via `Use`,
+the chain is aborted after the value is rendered. Middleware that should pass
+through should use a no-return Fox signature or `gin.HandlerFunc` directly.
 
 ### 5. Production Configuration
 

--- a/.github/README_zh.md
+++ b/.github/README_zh.md
@@ -183,7 +183,7 @@ func main() {
 $ curl -X POST http://localhost:8080/users/signup \
     -H 'content-type: application/json' \
     -d '{"username": "George", "email": "george@vandaley.com"}'
-{"code":"PASSWORD_TOO_SHORT"}
+{"code":"PASSWORD_TOO_SHORT","error":"(400): password too short"}
 ```
 
 ## 架构

--- a/.github/README_zh.md
+++ b/.github/README_zh.md
@@ -183,7 +183,7 @@ func main() {
 $ curl -X POST http://localhost:8080/users/signup \
     -H 'content-type: application/json' \
     -d '{"username": "George", "email": "george@vandaley.com"}'
-{"code":"PASSWORD_TOO_SHORT","error":"(400): password too short"}
+{"code":"PASSWORD_TOO_SHORT","error":"(400): password too short","meta":"password too short"}
 ```
 
 ## 架构

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+- `IsValidHandlerFunc` no longer accepts `interface` as the second parameter
+  type — handlers using `func(ctx, args any)` will now panic at registration.
+  Use a concrete `struct` or `map` type instead.
+- `logger.NewWithContext` no longer reads trace IDs from the
+  `logger.TraceID` string context key. Propagate trace IDs with
+  `logger.TraceIDKey` (the typed key) or via `logger.NewContext`.
+- `*httperrors.Error` returned from `IsValid()` is no longer wrapped as
+  `BIND_ERROR`. Consumers that matched on the `BIND_ERROR` response `code`
+  to detect binding failures should use the HTTP 400 status code or their
+  own specific codes instead.
+
 ### Added
 - `examples/*/main_test.go` smoke tests for all examples.
 - `render` package smoke test.
 - Gin baseline benchmarks for performance comparison.
 
 ### Changed
-- `httperrors.Error.MarshalJSON` now uses a pointer receiver.
-- `bind` skips body reads when `Content-Length` is 0 and no transfer encoding is present.
-- `DefaultValidator` now reuses the package-level `Validate` instance.
+- `httperrors.Error.MarshalJSON` no longer mutates its receiver and now
+  flattens `Meta` when it is either a struct or a pointer to a struct (via
+  `reflect.Indirect`). The method keeps a value receiver so that `Error` still
+  marshals correctly when used as a value (for example in `[]Error` slices
+  or `map[string]Error`).
+- `bind` skips body reads only when `Content-Length == 0` **and** no transfer
+  encoding is declared. Requests with unknown length (`Content-Length == -1`)
+  or chunked encoding continue to read the body as before.
+- `DefaultValidator` now reuses the package-level `Validate` instance, so
+  custom validations registered via `fox.Validate.RegisterValidation(...)`
+  are honored during binding.
 - Documentation now uses the actual `httperrors.Error` fields and JSON response keys.
 - Documentation now aligns Go version, security policy, performance reproduction notes, and release history.
 
 ### Fixed
 - Package-level `logger.Debug`, `Info`, `Warn`, `Error`, `Fatal`, and `Panic` now spread variadic arguments correctly.
-- `*httperrors.Error` returned from `IsValid()` is passed through without being wrapped as `BIND_ERROR`, preserving user-defined `Code` and `HTTPCode`.
-- `IsValid()` is now called for pointer handler parameters after binding.
+- `*httperrors.Error` returned from `IsValid()` (including values wrapped via
+  `fmt.Errorf("%w", ...)`) is passed through without being wrapped as
+  `BIND_ERROR`, preserving user-defined `Code` and `HTTPCode`. Detection uses
+  `errors.As` so any error chain containing a `*httperrors.Error` is unwrapped.
+- `IsValid()` is now called for pointer handler parameters after binding,
+  covering value-receiver implementations on the addressable parameter.
 
 ### Deprecated
 - `ErrInvalidHandlerType`; use `MsgInvalidHandlerType`.
@@ -131,7 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **⚠️ Beta Status**: This project is currently in beta. APIs may change without notice. Not recommended for production use until v1.0.0 release.
 
 ### Known Issues
-- Content negotiation by `Accept` header is pending and should be tracked in a GitHub issue before release.
+- Content negotiation by `Accept` header is pending — tracked in [#65](https://github.com/fox-gonic/fox/issues/65).
 - lumberjack dependency uses +incompatible version
 
 ### Upcoming Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `examples/*/main_test.go` smoke tests for all examples.
+- `render` package smoke test.
+- Gin baseline benchmarks for performance comparison.
+
+### Changed
+- `httperrors.Error.MarshalJSON` now uses a pointer receiver.
+- `bind` skips body reads when `Content-Length` is 0 and no transfer encoding is present.
+- `DefaultValidator` now reuses the package-level `Validate` instance.
+- Documentation now uses the actual `httperrors.Error` fields and JSON response keys.
+- Documentation now aligns Go version, security policy, performance reproduction notes, and release history.
+
+### Fixed
+- Package-level `logger.Debug`, `Info`, `Warn`, `Error`, `Fatal`, and `Panic` now spread variadic arguments correctly.
+- `*httperrors.Error` returned from `IsValid()` is passed through without being wrapped as `BIND_ERROR`, preserving user-defined `Code` and `HTTPCode`.
+- `IsValid()` is now called for pointer handler parameters after binding.
+
+### Deprecated
+- `ErrInvalidHandlerType`; use `MsgInvalidHandlerType`.
+
+### Removed
+- `logger.NewWithContext` no longer reads trace IDs from the `logger.TraceID` string context key. Use `TraceIDKey`.
+- `IsValidHandlerFunc` no longer accepts `interface` as the second parameter type.
+
 ## [0.0.10] - 2026-04-30
 
 ### Added
@@ -27,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `reponse_time.go` to `response_time.go` (typo correction)
 
 ## [0.1.0-beta] - 2024-12-06
+
+> Note: This pre-release tag has been deprecated. Subsequent releases follow the `0.0.x` track (see `[0.0.10]` above) and will continue until the project graduates to `0.1.0` stable.
 
 ### Added
 - Smart handler signature support with automatic parameter binding and rendering
@@ -105,7 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **⚠️ Beta Status**: This project is currently in beta. APIs may change without notice. Not recommended for production use until v1.0.0 release.
 
 ### Known Issues
-- TODO: Implement render by writer content-type (render.go:39, render.go:63)
+- Content negotiation by `Accept` header is pending and should be tracked in a GitHub issue before release.
 - lumberjack dependency uses +incompatible version
 
 ### Upcoming Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - `ErrInvalidHandlerType`; use `MsgInvalidHandlerType`.
 
-### Removed
-- `logger.NewWithContext` no longer reads trace IDs from the `logger.TraceID` string context key. Use `TraceIDKey`.
-- `IsValidHandlerFunc` no longer accepts `interface` as the second parameter type.
-
 ## [0.0.10] - 2026-04-30
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This project and everyone participating in it is governed by our Code of Conduct
 
 ### Prerequisites
 
-- Go 1.24.0 or later
+- Go 1.25.0 or later
 - Git
 - golangci-lint v2.7.1 or later (for linting)
 - Make (optional, but recommended)
@@ -72,7 +72,7 @@ Unsure where to begin? You can start by looking through issues labeled:
 
 - `good first issue` - Simple issues suitable for newcomers
 - `help wanted` - Issues where we need community help
-- Check the [TODO.md](TODO.md) for a list of planned improvements
+- Check the [GitHub Issues](https://github.com/fox-gonic/fox/issues) for planned improvements
 
 ### Pull Requests
 
@@ -560,7 +560,7 @@ git push origin feat/my-new-feature
 ## Getting Help
 
 - 📖 Check the [README](.github/README.md)
-- 📝 Review [TODO.md](TODO.md) for planned work
+- 📝 Review [GitHub Issues](https://github.com/fox-gonic/fox/issues) for planned work
 - 💬 Open a [Discussion](https://github.com/fox-gonic/fox/discussions)
 - 🐛 Open an [Issue](https://github.com/fox-gonic/fox/issues)
 - 📧 Email: [miclle.zheng@gmail.com](mailto:miclle.zheng@gmail.com)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release patches for security vulnerabilities. Currently, the following versio
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x (beta)   | :white_check_mark: |
-| < 0.1.0 | :x:                |
+| 0.0.x (>= 0.0.10) | :white_check_mark: |
+| < 0.0.10 | :x:                |
 
 **Note**: Fox is currently in beta. While we take security seriously, please be aware that the API may change and the framework is not yet recommended for production use.
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 // ==================== Engine/Routing Benchmarks ====================
@@ -116,6 +118,48 @@ func BenchmarkEngine_JSONResponse(b *testing.B) {
 			Username: "john",
 			Email:    "john@example.com",
 		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/user", nil)
+	w := httptest.NewRecorder()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(w, req)
+	}
+}
+
+func BenchmarkGin_Baseline_SimpleRoute(b *testing.B) {
+	router := gin.New()
+	router.GET("/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "pong")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		router.ServeHTTP(w, req)
+	}
+}
+
+func BenchmarkGin_Baseline_JSONResponse(b *testing.B) {
+	type User struct {
+		ID       int64  `json:"id"`
+		Username string `json:"username"`
+		Email    string `json:"email"`
+	}
+
+	router := gin.New()
+	router.GET("/user", func(c *gin.Context) {
+		c.JSON(http.StatusOK, &User{
+			ID:       123,
+			Username: "john",
+			Email:    "john@example.com",
+		})
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/user", nil)

--- a/binding.go
+++ b/binding.go
@@ -57,8 +57,7 @@ func bind(ctx *Context, obj any) error {
 	)
 
 	shouldReadBody := ctx.Request.ContentLength != 0 ||
-		len(ctx.Request.TransferEncoding) > 0 ||
-		ctx.Request.Header.Get("Transfer-Encoding") != ""
+		len(ctx.Request.TransferEncoding) > 0
 	if shouldReadBody {
 		if body, err = ctx.RequestBody(); err != nil {
 			return err

--- a/binding.go
+++ b/binding.go
@@ -56,14 +56,19 @@ func bind(ctx *Context, obj any) error {
 		err         error
 	)
 
-	if body, err = ctx.RequestBody(); err != nil {
-		return err
-	}
+	shouldReadBody := ctx.Request.ContentLength != 0 ||
+		len(ctx.Request.TransferEncoding) > 0 ||
+		ctx.Request.Header.Get("Transfer-Encoding") != ""
+	if shouldReadBody {
+		if body, err = ctx.RequestBody(); err != nil {
+			return err
+		}
 
-	defer func() {
-		// copy the request body to the next handler
-		ctx.Request.Body = io.NopCloser(bytes.NewBuffer(body))
-	}()
+		defer func() {
+			// copy the request body to the next handler
+			ctx.Request.Body = io.NopCloser(bytes.NewBuffer(body))
+		}()
+	}
 
 	if ctx.Request.Method == http.MethodGet {
 		err = binding.Form.Bind(ctx.Request, obj)
@@ -150,6 +155,11 @@ func bind(ctx *Context, obj any) error {
 
 	if valider, ok := obj.(IsValider); ok {
 		return valider.IsValid()
+	}
+	if vPtr.CanAddr() {
+		if valider, ok := vPtr.Addr().Interface().(IsValider); ok {
+			return valider.IsValid()
+		}
 	}
 
 	return nil

--- a/binding_test.go
+++ b/binding_test.go
@@ -481,6 +481,7 @@ func TestBind_RequestBodyError(t *testing.T) {
 	// Create a request with a body that will cause an error when reading
 	req, _ := http.NewRequest(http.MethodPost, "/", errReader(0))
 	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = -1
 
 	ctx := &Context{
 		Context: &gin.Context{
@@ -637,4 +638,26 @@ func TestBind_CustomBinder(t *testing.T) {
 	err := bind(ctx, &obj)
 	require.Error(t, err)
 	assert.Equal(t, "custom binder error", err.Error())
+}
+
+func BenchmarkBinding_NoBody_QueryOnly(b *testing.B) {
+	type QueryRequest struct {
+		Name string `query:"name"`
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "/?name=fox", nil)
+	req.ContentLength = 0
+	ctx := &Context{
+		Context: &gin.Context{Request: req},
+		Request: req,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var obj QueryRequest
+		if err := bind(ctx, &obj); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/call.go
+++ b/call.go
@@ -1,6 +1,7 @@
 package fox
 
 import (
+	"errors"
 	"net/http"
 	"reflect"
 
@@ -33,6 +34,10 @@ func call(ctx *Context, handler HandlerFunc) any {
 			// Bind handler params
 			parameter := reflect.New(funcType.In(i)).Interface()
 			if err := bind(ctx, parameter); err != nil {
+				var httpErr *httperrors.Error
+				if errors.As(err, &httpErr) {
+					return httpErr
+				}
 				msg := &httperrors.Error{
 					HTTPCode: http.StatusBadRequest,
 					Err:      err,

--- a/call_test.go
+++ b/call_test.go
@@ -240,6 +240,31 @@ func TestCall_BindingError(t *testing.T) {
 	})
 }
 
+func TestCall_IsValiderHTTPError_PreservesCode(t *testing.T) {
+	engine := New()
+	engine.POST("/signup", func(c *Context, args *CreateUserArgs) string {
+		return "ok"
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/signup",
+		strings.NewReader(`{"username":"George","email":"george@example.com"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "PASSWORD_TOO_SHORT", resp["code"])
+	assert.Equal(t, "(400): password too short", resp["error"])
+	assert.NotEqual(t, "BIND_ERROR", resp["code"])
+}
+
 func TestCall_MultipleParameters(t *testing.T) {
 	engine := New()
 	body := `{"name":"John","age":30}`

--- a/context.go
+++ b/context.go
@@ -47,7 +47,12 @@ func (c *Context) RequestBody() (body []byte, err error) {
 	return body, err
 }
 
-// TraceID return request id
+// TraceID returns the request trace ID. It checks the gin context, request
+// header, and response header in order, falling back to generating a new ID
+// which is then written to both the response header and gin context.
+//
+// Note: This method has a side effect when no trace ID exists. If you only
+// want to read without generating, check c.GetHeader(logger.TraceID) directly.
 func (c *Context) TraceID() string {
 	if id, exists := c.Get(logger.TraceID); exists {
 		return id.(string)

--- a/domain.go
+++ b/domain.go
@@ -42,12 +42,20 @@ func NewDefaultDomainEngine() *DomainEngine {
 	return NewDomainEngine(Default)
 }
 
-// Domain add domain handler
+// Domain registers an exact-match domain handler.
+//
+// Domains are matched in registration order. The first match wins, regardless
+// of whether it is exact or regexp. Register regexp patterns after exact
+// domains to avoid accidental shadowing.
 func (engine *DomainEngine) Domain(name string, engineFunc func(subEngine *Engine)) {
 	engine.server(name, false, engineFunc)
 }
 
-// DomainRegexp add domain handler
+// DomainRegexp registers a regexp domain handler.
+//
+// Domains are matched in registration order. The first match wins, regardless
+// of whether it is exact or regexp. Register regexp patterns after exact
+// domains to avoid accidental shadowing.
 func (engine *DomainEngine) DomainRegexp(name string, engineFunc func(subEngine *Engine)) {
 	engine.server(name, true, engineFunc)
 }

--- a/engine.go
+++ b/engine.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -49,8 +50,8 @@ var DefaultWriter io.Writer = os.Stdout
 // DefaultErrorWriter is the default io.Writer used by Gin to debug errors.
 var DefaultErrorWriter io.Writer = os.Stderr
 
-// ErrInvalidHandlerType is the error message for invalid handler type.
-var ErrInvalidHandlerType = "invalid handler type: %s\n" +
+// MsgInvalidHandlerType is the panic message format for invalid handler types.
+var MsgInvalidHandlerType = "invalid handler type: %s\n" +
 	"handler signature: %s\n" +
 	"Supported handler types:\n" +
 	"1. func()\n" +
@@ -62,6 +63,9 @@ var ErrInvalidHandlerType = "invalid handler type: %s\n" +
 	"- S can be struct or map type, S will be auto binding from request body\n" +
 	"- T can be any type, T will be auto render to response body\n" +
 	"- error can be any type that implements error interface"
+
+// Deprecated: Use MsgInvalidHandlerType. This alias will be removed in v0.1.0.
+var ErrInvalidHandlerType = MsgInvalidHandlerType
 
 // HandlerFunc is a function that can be registered to a route to handle HTTP requests.
 // Like http.HandlerFunc, but support auto binding and auto render.
@@ -77,6 +81,11 @@ var ErrInvalidHandlerType = "invalid handler type: %s\n" +
 //   - S can be struct or map type, S will be auto binding from request body
 //   - T can be any type, T will be auto render to response body
 //   - error can be any type that implements error interface
+//
+// IMPORTANT: When a handler with a non-nil return value is used as middleware
+// through Use, the chain is aborted after the value is rendered. For middleware
+// that should pass through, use a signature without return values or use
+// gin.HandlerFunc directly.
 type HandlerFunc any
 
 // HandlersChain defines a HandlerFunc slice.
@@ -107,16 +116,16 @@ type Engine struct {
 
 	handlerRoutesMu       sync.RWMutex
 	handlerRoutes         map[handlerRouteKey]RouteInfo
-	handlerRoutesDisabled bool
+	handlerRoutesDisabled atomic.Bool
 }
 
 // DisableRouteRegistry stops collecting handler reflection metadata for new
 // routes. Existing entries are dropped. Use when you do not run any tooling
 // (such as openapi generation) and want to free the per-route memory.
 func (engine *Engine) DisableRouteRegistry() {
+	engine.handlerRoutesDisabled.Store(true)
 	engine.handlerRoutesMu.Lock()
 	defer engine.handlerRoutesMu.Unlock()
-	engine.handlerRoutesDisabled = true
 	engine.handlerRoutes = nil
 }
 
@@ -221,7 +230,7 @@ func IsValidHandlerFunc(handler HandlerFunc) bool {
 			secondParam = secondParam.Elem()
 		}
 		// Check if it's a struct or map type
-		if secondParam.Kind() != reflect.Struct && secondParam.Kind() != reflect.Map && secondParam.Kind() != reflect.Interface {
+		if secondParam.Kind() != reflect.Struct && secondParam.Kind() != reflect.Map {
 			return false
 		}
 	}

--- a/engine_test.go
+++ b/engine_test.go
@@ -285,7 +285,7 @@ func TestIsValidHandlerFunc(t *testing.T) {
 		{
 			name:     "HTTP error with interface parameter",
 			handler:  func(ctx *fox.Context, args any) ([]byte, *HTTPError) { return nil, nil },
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "Non-error second return type",

--- a/examples/01-basic/main.go
+++ b/examples/01-basic/main.go
@@ -5,6 +5,15 @@ import (
 )
 
 func main() {
+	router := newRouter()
+
+	// Start server on port 8080
+	if err := router.Run(":8080"); err != nil {
+		panic(err)
+	}
+}
+
+func newRouter() *fox.Engine {
 	// Create a new Fox engine
 	router := fox.New()
 
@@ -23,7 +32,7 @@ func main() {
 	type UserParams struct {
 		Name string `uri:"name" binding:"required"`
 	}
-	router.GET("/greet/:name", func(params UserParams) string {
+	router.GET("/greet/:name", func(_ *fox.Context, params UserParams) string {
 		return "Greetings, " + params.Name + "!"
 	})
 
@@ -34,8 +43,5 @@ func main() {
 		}
 	})
 
-	// Start server on port 8080
-	if err := router.Run(":8080"); err != nil {
-		panic(err)
-	}
+	return router
 }

--- a/examples/01-basic/main_test.go
+++ b/examples/01-basic/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicRoutes(t *testing.T) {
+	router := newRouter()
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "pong", w.Body.String())
+}

--- a/examples/02-binding/main.go
+++ b/examples/02-binding/main.go
@@ -39,6 +39,14 @@ type QueryUsersRequest struct {
 }
 
 func main() {
+	router := newRouter()
+
+	if err := router.Run(":8080"); err != nil {
+		panic(err)
+	}
+}
+
+func newRouter() *fox.Engine {
 	router := fox.New()
 
 	// POST: Create user with JSON body binding
@@ -114,7 +122,5 @@ func main() {
 		return "Validation passed", nil
 	})
 
-	if err := router.Run(":8080"); err != nil {
-		panic(err)
-	}
+	return router
 }

--- a/examples/02-binding/main_test.go
+++ b/examples/02-binding/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindingRoutes(t *testing.T) {
+	router := newRouter()
+	req := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader(`{
+		"username":"alice",
+		"email":"alice@example.com",
+		"password":"secret1",
+		"age":25
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"username":"alice"`)
+}

--- a/examples/03-middleware/main.go
+++ b/examples/03-middleware/main.go
@@ -77,6 +77,14 @@ func RequestIDMiddleware() gin.HandlerFunc {
 }
 
 func main() {
+	router := newRouter()
+
+	if err := router.Run(":8080"); err != nil {
+		panic(err)
+	}
+}
+
+func newRouter() *fox.Engine {
 	router := fox.New()
 
 	// Global middlewares
@@ -151,7 +159,5 @@ func main() {
 		return "Logged"
 	})
 
-	if err := router.Run(":8080"); err != nil {
-		panic(err)
-	}
+	return router
 }

--- a/examples/03-middleware/main_test.go
+++ b/examples/03-middleware/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddlewareRoutes(t *testing.T) {
+	router := newRouter()
+	req := httptest.NewRequest(http.MethodGet, "/api/profile", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"username":"alice"`)
+}

--- a/examples/04-domain-routing/main.go
+++ b/examples/04-domain-routing/main.go
@@ -5,6 +5,15 @@ import (
 )
 
 func main() {
+	de := newRouter()
+
+	// Start server
+	if err := de.Run(":8080"); err != nil {
+		panic(err)
+	}
+}
+
+func newRouter() *fox.DomainEngine {
 	// Create domain engine
 	de := fox.NewDomainEngine()
 
@@ -118,8 +127,5 @@ func main() {
 		}
 	})
 
-	// Start server
-	if err := de.Run(":8080"); err != nil {
-		panic(err)
-	}
+	return de
 }

--- a/examples/04-domain-routing/main_test.go
+++ b/examples/04-domain-routing/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDomainRoutes(t *testing.T) {
+	router := newRouter()
+	req := httptest.NewRequest(http.MethodGet, "http://api.example.com/status", nil)
+	req.Host = "api.example.com"
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"status":"API service running"`)
+}

--- a/examples/05-custom-validator/README.md
+++ b/examples/05-custom-validator/README.md
@@ -180,7 +180,7 @@ func (sr *SignupRequest) IsValid() error {
         return &httperrors.Error{
             HTTPCode: http.StatusBadRequest,
             Code:     "RESERVED_USERNAME",
-            Message:  "Username is reserved",
+            Err:      errors.New("username is reserved"),
         }
     }
     return nil
@@ -193,10 +193,10 @@ Custom validators should return `*httperrors.Error` for consistent error handlin
 
 ```go
 return &httperrors.Error{
-    HTTPCode: http.StatusBadRequest,  // HTTP status code
-    Code:     "ERROR_CODE",            // Machine-readable code
-    Message:  "Human-readable message", // User-friendly message
-    Err:      errors.New("internal error"), // Internal error (optional)
+    HTTPCode: http.StatusBadRequest,        // HTTP status code
+    Code:     "ERROR_CODE",                 // Machine-readable code
+    Err:      errors.New("human-readable message"), // Error message
+    Meta:     map[string]any{"field": "value"},     // Optional metadata
 }
 ```
 

--- a/examples/05-custom-validator/main.go
+++ b/examples/05-custom-validator/main.go
@@ -165,6 +165,14 @@ func (cpr *CreatePostRequest) IsValid() error {
 }
 
 func main() {
+	router := newRouter()
+
+	if err := router.Run(":8080"); err != nil {
+		panic(err)
+	}
+}
+
+func newRouter() *fox.Engine {
 	router := fox.New()
 
 	// Password validation endpoint
@@ -193,7 +201,5 @@ func main() {
 		}, nil
 	})
 
-	if err := router.Run(":8080"); err != nil {
-		panic(err)
-	}
+	return router
 }

--- a/examples/05-custom-validator/main_test.go
+++ b/examples/05-custom-validator/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomValidatorRoutes(t *testing.T) {
+	router := newRouter()
+	req := httptest.NewRequest(http.MethodPost, "/validate-password", strings.NewReader(`{"password":"Strong1!"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "Password is strong!", w.Body.String())
+}

--- a/examples/06-error-handling/README.md
+++ b/examples/06-error-handling/README.md
@@ -43,7 +43,7 @@ Expected response:
 ```json
 {
   "code": "BAD_REQUEST",
-  "message": "The request was invalid"
+  "error": "(400): the request was invalid"
 }
 ```
 
@@ -153,12 +153,10 @@ Expected response:
 ```json
 {
   "code": "VALIDATION_FAILED",
-  "message": "Request validation failed",
-  "details": {
-    "field": "email",
-    "reason": "invalid format",
-    "value": "not-an-email"
-  }
+  "error": "(400): request validation failed",
+  "field": "email",
+  "reason": "invalid format",
+  "value": "not-an-email"
 }
 ```
 
@@ -189,7 +187,7 @@ Response:
 return "", &httperrors.Error{
     HTTPCode: http.StatusBadRequest,
     Code:     "ERROR_CODE",
-    Message:  "Error message",
+    Err:      errors.New("error message"),
 }
 ```
 
@@ -197,7 +195,7 @@ Response (400):
 ```json
 {
   "code": "ERROR_CODE",
-  "message": "Error message"
+  "error": "(400): error message"
 }
 ```
 
@@ -207,8 +205,8 @@ Response (400):
 return "", &httperrors.Error{
     HTTPCode: http.StatusBadRequest,
     Code:     "ERROR_CODE",
-    Message:  "Error message",
-    Details:  map[string]interface{}{"field": "value"},
+    Err:      errors.New("error message"),
+    Fields:   map[string]any{"field": "value"},
 }
 ```
 
@@ -216,8 +214,8 @@ Response (400):
 ```json
 {
   "code": "ERROR_CODE",
-  "message": "Error message",
-  "details": {"field": "value"}
+  "error": "(400): error message",
+  "field": "value"
 }
 ```
 
@@ -230,7 +228,6 @@ var ErrUserNotFound = &httperrors.Error{
     HTTPCode: http.StatusNotFound,
     Err:      errors.New("user not found"),
     Code:     "USER_NOT_FOUND",
-    Message:  "The requested user does not exist",
 }
 
 // Use in handler

--- a/examples/06-error-handling/main.go
+++ b/examples/06-error-handling/main.go
@@ -44,6 +44,14 @@ type User struct {
 }
 
 func main() {
+	router := newRouter()
+
+	if err := router.Run(":8080"); err != nil {
+		panic(err)
+	}
+}
+
+func newRouter() *fox.Engine {
 	router := fox.New()
 
 	// Simple error return
@@ -203,7 +211,5 @@ func main() {
 		panic("something went wrong!")
 	})
 
-	if err := router.Run(":8080"); err != nil {
-		panic(err)
-	}
+	return router
 }

--- a/examples/06-error-handling/main_test.go
+++ b/examples/06-error-handling/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorHandlingRoutes(t *testing.T) {
+	router := newRouter()
+	req := httptest.NewRequest(http.MethodGet, "/error/http", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), `"code":"BAD_REQUEST"`)
+}

--- a/examples/07-logger-config/main.go
+++ b/examples/07-logger-config/main.go
@@ -24,6 +24,21 @@ func main() {
 	example5LogLevels()
 }
 
+func newRouter() *fox.Engine {
+	logger.SetConfig(&logger.Config{
+		LogLevel:              logger.InfoLevel,
+		ConsoleLoggingEnabled: false,
+		EncodeLogsAsJSON:      true,
+	})
+
+	router := fox.New()
+	router.Use(fox.Logger(fox.LoggerConfig{SkipPaths: []string{"/health"}}))
+	router.GET("/health", func() string {
+		return "OK"
+	})
+	return router
+}
+
 // Example 1: Console logging only (development mode)
 func example1ConsoleOnly() {
 	logger.SetConfig(&logger.Config{

--- a/examples/07-logger-config/main_test.go
+++ b/examples/07-logger-config/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerConfigRoutes(t *testing.T) {
+	router := newRouter()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "OK", w.Body.String())
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,7 +80,7 @@ router.POST("/users", func(ctx *fox.Context, req *CreateUserRequest) (*User, err
 var ErrNotFound = &httperrors.Error{
     HTTPCode: http.StatusNotFound,
     Code:     "NOT_FOUND",
-    Message:  "Resource not found",
+    Err:      errors.New("resource not found"),
 }
 
 router.GET("/user/:id", func(ctx *fox.Context) (*User, error) {
@@ -121,7 +121,7 @@ func (sr *SignupRequest) IsValid() error {
         return &httperrors.Error{
             HTTPCode: http.StatusBadRequest,
             Code:     "WEAK_PASSWORD",
-            Message:  "Password must be at least 8 characters",
+            Err:      errors.New("password must be at least 8 characters"),
         }
     }
     return nil

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/json-iterator/go v1.1.12
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/httperrors/errors.go
+++ b/httperrors/errors.go
@@ -9,12 +9,9 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/mitchellh/mapstructure"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
-
-var newMapstructureDecoder = mapstructure.NewDecoder
 
 // New returns a new http Error object
 func New(httpCode int, format string, a ...any) *Error {
@@ -150,24 +147,18 @@ func (e Error) MarshalJSON() ([]byte, error) {
 			jsonData["meta"] = err.Error()
 		} else {
 			value := reflect.ValueOf(meta)
-			if value.Kind() == reflect.Ptr {
-				value = reflect.Indirect(value)
+			kind := value.Kind()
+			if kind == reflect.Ptr && !value.IsNil() {
+				kind = value.Elem().Kind()
 			}
-			switch value.Kind() {
-			case reflect.Struct:
-				decoder, err := newMapstructureDecoder(&mapstructure.DecoderConfig{
-					TagName: "json",
-					Result:  &jsonData,
-				})
+			switch kind {
+			case reflect.Struct, reflect.Map:
+				data, err := json.Marshal(meta)
 				if err != nil {
 					return nil, err
 				}
-				if err := decoder.Decode(value.Interface()); err != nil {
+				if err := json.Unmarshal(data, &jsonData); err != nil {
 					return nil, err
-				}
-			case reflect.Map:
-				for _, key := range value.MapKeys() {
-					jsonData[key.String()] = value.MapIndex(key).Interface()
 				}
 			default:
 				jsonData["meta"] = meta

--- a/httperrors/errors.go
+++ b/httperrors/errors.go
@@ -147,11 +147,10 @@ func (e Error) MarshalJSON() ([]byte, error) {
 			jsonData["meta"] = err.Error()
 		} else {
 			value := reflect.ValueOf(meta)
-			kind := value.Kind()
-			if kind == reflect.Ptr && !value.IsNil() {
-				kind = value.Elem().Kind()
+			for value.Kind() == reflect.Ptr && !value.IsNil() {
+				value = value.Elem()
 			}
-			switch kind {
+			switch value.Kind() {
 			case reflect.Struct, reflect.Map:
 				data, err := json.Marshal(meta)
 				if err != nil {

--- a/httperrors/errors.go
+++ b/httperrors/errors.go
@@ -153,16 +153,11 @@ func (e Error) MarshalJSON() ([]byte, error) {
 			}
 			switch value.Kind() {
 			case reflect.Struct:
-				decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				decoder, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 					TagName: "json",
 					Result:  &jsonData,
 				})
-				if err != nil {
-					return nil, err
-				}
-				if err := decoder.Decode(value.Interface()); err != nil {
-					return nil, err
-				}
+				_ = decoder.Decode(value.Interface())
 			case reflect.Map:
 				for _, key := range value.MapKeys() {
 					jsonData[key.String()] = value.MapIndex(key).Interface()

--- a/httperrors/errors.go
+++ b/httperrors/errors.go
@@ -14,6 +14,8 @@ import (
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
+var newMapstructureDecoder = mapstructure.NewDecoder
+
 // New returns a new http Error object
 func New(httpCode int, format string, a ...any) *Error {
 	if strings.TrimSpace(format) == "" {
@@ -153,11 +155,16 @@ func (e Error) MarshalJSON() ([]byte, error) {
 			}
 			switch value.Kind() {
 			case reflect.Struct:
-				decoder, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				decoder, err := newMapstructureDecoder(&mapstructure.DecoderConfig{
 					TagName: "json",
 					Result:  &jsonData,
 				})
-				_ = decoder.Decode(value.Interface())
+				if err != nil {
+					return nil, err
+				}
+				if err := decoder.Decode(value.Interface()); err != nil {
+					return nil, err
+				}
 			case reflect.Map:
 				for _, key := range value.MapKeys() {
 					jsonData[key.String()] = value.MapIndex(key).Interface()

--- a/httperrors/errors.go
+++ b/httperrors/errors.go
@@ -128,15 +128,16 @@ func (e *Error) Is(target error) bool {
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (e Error) MarshalJSON() ([]byte, error) {
+func (e *Error) MarshalJSON() ([]byte, error) {
 	jsonData := map[string]any{}
 
-	if e.Meta == nil {
-		e.Meta = e.Err
+	meta := e.Meta
+	if meta == nil {
+		meta = e.Err
 	}
 
-	if e.Meta != nil {
-		value := reflect.ValueOf(e.Meta)
+	if meta != nil {
+		value := reflect.ValueOf(meta)
 		switch value.Kind() {
 		case reflect.Struct:
 			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
@@ -146,7 +147,7 @@ func (e Error) MarshalJSON() ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			if err := decoder.Decode(e.Meta); err != nil {
+			if err := decoder.Decode(meta); err != nil {
 				return nil, err
 			}
 		case reflect.Map:
@@ -154,10 +155,10 @@ func (e Error) MarshalJSON() ([]byte, error) {
 				jsonData[key.String()] = value.MapIndex(key).Interface()
 			}
 		default:
-			if err, ok := e.Meta.(error); ok {
+			if err, ok := meta.(error); ok {
 				jsonData["meta"] = err.Error()
 			} else {
-				jsonData["meta"] = e.Meta
+				jsonData["meta"] = meta
 			}
 		}
 	}

--- a/httperrors/errors.go
+++ b/httperrors/errors.go
@@ -128,7 +128,11 @@ func (e *Error) Is(target error) bool {
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (e *Error) MarshalJSON() ([]byte, error) {
+//
+// The receiver is a value so that MarshalJSON is invoked for both value and
+// pointer usages (for example `[]Error` slices or `map[string]Error`). Any
+// state mutation must go through local variables rather than the receiver.
+func (e Error) MarshalJSON() ([]byte, error) {
 	jsonData := map[string]any{}
 
 	meta := e.Meta
@@ -137,27 +141,33 @@ func (e *Error) MarshalJSON() ([]byte, error) {
 	}
 
 	if meta != nil {
-		value := reflect.ValueOf(meta)
-		switch value.Kind() {
-		case reflect.Struct:
-			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-				TagName: "json",
-				Result:  &jsonData,
-			})
-			if err != nil {
-				return nil, err
+		// Handle error values (including pointer-to-errorString wrapped in the
+		// error interface) before the kind switch so that they are reported as
+		// a string instead of being reflectively decoded.
+		if err, ok := meta.(error); ok {
+			jsonData["meta"] = err.Error()
+		} else {
+			value := reflect.ValueOf(meta)
+			if value.Kind() == reflect.Ptr {
+				value = reflect.Indirect(value)
 			}
-			if err := decoder.Decode(meta); err != nil {
-				return nil, err
-			}
-		case reflect.Map:
-			for _, key := range value.MapKeys() {
-				jsonData[key.String()] = value.MapIndex(key).Interface()
-			}
-		default:
-			if err, ok := meta.(error); ok {
-				jsonData["meta"] = err.Error()
-			} else {
+			switch value.Kind() {
+			case reflect.Struct:
+				decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+					TagName: "json",
+					Result:  &jsonData,
+				})
+				if err != nil {
+					return nil, err
+				}
+				if err := decoder.Decode(value.Interface()); err != nil {
+					return nil, err
+				}
+			case reflect.Map:
+				for _, key := range value.MapKeys() {
+					jsonData[key.String()] = value.MapIndex(key).Interface()
+				}
+			default:
 				jsonData["meta"] = meta
 			}
 		}

--- a/httperrors/errors_test.go
+++ b/httperrors/errors_test.go
@@ -206,6 +206,7 @@ func TestMarshalJSON_MetaNil(t *testing.T) {
 	r.Equal("TEST_ERROR", obj["code"])
 	r.Equal("(400): test error", obj["error"])
 	r.Equal("test error", obj["meta"])
+	r.Nil(err.Meta)
 }
 
 // TestMarshalJSON_CodeEmpty tests MarshalJSON with empty Code

--- a/httperrors/errors_test.go
+++ b/httperrors/errors_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,8 +80,8 @@ func TestError(t *testing.T) {
 		}, obj["details"])
 		r.Equal("400", fmt.Sprintf("%v", obj["code"]))
 		r.Equal("invalid_arguments", obj["error_code"])
-		r.Empty(obj["omit_empty_field"])
-		r.Empty(obj["ignore_field"])
+		r.NotContains(obj, "omit_empty_field")
+		r.NotContains(obj, "ignore_field")
 		r.Equal("hvnmjnCVyvQ3aOIX", obj["x-request-id"])
 		r.Equal("1.799868", fmt.Sprintf("%v", obj["latency"]))
 		r.Equal("HANDLER", obj["ftype"])
@@ -338,6 +337,56 @@ func TestMarshalJSON_MetaWithMap(t *testing.T) {
 	r.Equal("TEST_CODE", obj["code"])
 }
 
+func TestMarshalJSON_MetaWithNonStringMapKeys(t *testing.T) {
+	r := require.New(t)
+
+	err := &Error{
+		HTTPCode: 400,
+		Err:      errors.New("test error"),
+		Code:     "TEST_CODE",
+		Meta: map[int]string{
+			1: "one",
+			2: "two",
+		},
+	}
+
+	data, e := json.Marshal(err)
+	r.NoError(e)
+
+	var obj map[string]any
+	r.NoError(json.Unmarshal(data, &obj))
+	r.Equal("one", obj["1"])
+	r.Equal("two", obj["2"])
+	r.Equal("TEST_CODE", obj["code"])
+}
+
+func TestMarshalJSON_MetaStructHonorsJSONTags(t *testing.T) {
+	r := require.New(t)
+
+	err := &Error{
+		HTTPCode: 400,
+		Err:      errors.New("test error"),
+		Meta: struct {
+			Visible string `json:"visible"`
+			Empty   string `json:"empty,omitempty"`
+			Ignored string `json:"-"`
+		}{
+			Visible: "yes",
+			Ignored: "no",
+		},
+	}
+
+	data, e := json.Marshal(err)
+	r.NoError(e)
+
+	var obj map[string]any
+	r.NoError(json.Unmarshal(data, &obj))
+	r.Equal("yes", obj["visible"])
+	r.NotContains(obj, "empty")
+	r.NotContains(obj, "Ignored")
+	r.NotContains(obj, "ignored")
+}
+
 // TestMarshalJSON_MetaWithPrimitiveType tests MarshalJSON with primitive type as Meta
 func TestMarshalJSON_MetaWithPrimitiveType(t *testing.T) {
 	r := require.New(t)
@@ -426,41 +475,17 @@ func TestMarshalJSON_ValueReceiver(t *testing.T) {
 	r.NotContains(arr[0], "Err")
 }
 
-func TestMarshalJSON_MapstructureNewDecoderError(t *testing.T) {
-	r := require.New(t)
-
-	original := newMapstructureDecoder
-	t.Cleanup(func() {
-		newMapstructureDecoder = original
-	})
-	newMapstructureDecoder = func(*mapstructure.DecoderConfig) (*mapstructure.Decoder, error) {
-		return nil, errors.New("decoder setup failed")
-	}
-
-	err := &Error{
-		HTTPCode: 400,
-		Err:      errors.New("validation failed"),
-		Meta: struct {
-			Field string `json:"field"`
-		}{Field: "value"},
-	}
-
-	_, e := json.Marshal(err)
-	r.ErrorContains(e, "decoder setup failed")
-}
-
-func TestMarshalJSON_MapstructureDecodeError(t *testing.T) {
+func TestMarshalJSON_MetaJSONMarshalError(t *testing.T) {
 	r := require.New(t)
 
 	err := &Error{
 		HTTPCode: 400,
 		Err:      errors.New("validation failed"),
 		Meta: struct {
-			//nolint:staticcheck // Intentionally exercises mapstructure's squash error path.
-			Invalid int `json:",squash"`
-		}{Invalid: 1},
+			Invalid func() `json:"invalid"`
+		}{Invalid: func() {}},
 	}
 
 	_, e := json.Marshal(err)
-	r.ErrorContains(e, "cannot squash non-struct type")
+	r.ErrorContains(e, "unsupported type")
 }

--- a/httperrors/errors_test.go
+++ b/httperrors/errors_test.go
@@ -24,6 +24,12 @@ type ErrorInfo struct {
 	IgnoreField    string   `json:"-"`
 }
 
+type arrayJSONMeta struct{}
+
+func (arrayJSONMeta) MarshalJSON() ([]byte, error) {
+	return []byte(`[]`), nil
+}
+
 func TestError(t *testing.T) {
 	r := require.New(t)
 	err := New(400, "invalid arguments")
@@ -488,4 +494,17 @@ func TestMarshalJSON_MetaJSONMarshalError(t *testing.T) {
 
 	_, e := json.Marshal(err)
 	r.ErrorContains(e, "unsupported type")
+}
+
+func TestMarshalJSON_MetaJSONUnmarshalError(t *testing.T) {
+	r := require.New(t)
+
+	err := &Error{
+		HTTPCode: 400,
+		Err:      errors.New("validation failed"),
+		Meta:     arrayJSONMeta{},
+	}
+
+	_, e := json.Marshal(err)
+	r.ErrorContains(e, "expect { or n")
 }

--- a/httperrors/errors_test.go
+++ b/httperrors/errors_test.go
@@ -370,3 +370,57 @@ func TestMarshalJSON_MetaWithPrimitiveType(t *testing.T) {
 	r.NoError(e)
 	r.InEpsilon(42, obj["meta"].(float64), 0.001)
 }
+
+// TestMarshalJSON_MetaPointerToStruct ensures that a pointer to a struct is
+// flattened like a value struct, instead of landing in the default branch.
+func TestMarshalJSON_MetaPointerToStruct(t *testing.T) {
+	r := require.New(t)
+
+	type Details struct {
+		Field string `json:"field"`
+		Count int    `json:"count"`
+	}
+
+	err := &Error{
+		HTTPCode: 400,
+		Err:      errors.New("validation failed"),
+		Code:     "TEST_CODE",
+		Meta:     &Details{Field: "value", Count: 3},
+	}
+
+	data, e := json.Marshal(err)
+	r.NoError(e)
+
+	var obj map[string]any
+	r.NoError(json.Unmarshal(data, &obj))
+
+	r.Equal("value", obj["field"])
+	r.InDelta(3, obj["count"].(float64), 0.001)
+	r.NotContains(obj, "meta")
+}
+
+// TestMarshalJSON_ValueReceiver ensures that MarshalJSON is invoked when
+// Error is used as a value (e.g. in slices), not only through a pointer.
+func TestMarshalJSON_ValueReceiver(t *testing.T) {
+	r := require.New(t)
+
+	errs := []Error{
+		{
+			HTTPCode: 400,
+			Err:      errors.New("first"),
+			Code:     "FIRST",
+		},
+	}
+
+	data, e := json.Marshal(errs)
+	r.NoError(e)
+
+	var arr []map[string]any
+	r.NoError(json.Unmarshal(data, &arr))
+	r.Len(arr, 1)
+	r.Equal("FIRST", arr[0]["code"])
+	r.Equal("(400): first", arr[0]["error"])
+	// Ensure internal fields are not exposed via default struct marshaling.
+	r.NotContains(arr[0], "HTTPCode")
+	r.NotContains(arr[0], "Err")
+}

--- a/httperrors/errors_test.go
+++ b/httperrors/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 )
 
@@ -423,4 +424,43 @@ func TestMarshalJSON_ValueReceiver(t *testing.T) {
 	// Ensure internal fields are not exposed via default struct marshaling.
 	r.NotContains(arr[0], "HTTPCode")
 	r.NotContains(arr[0], "Err")
+}
+
+func TestMarshalJSON_MapstructureNewDecoderError(t *testing.T) {
+	r := require.New(t)
+
+	original := newMapstructureDecoder
+	t.Cleanup(func() {
+		newMapstructureDecoder = original
+	})
+	newMapstructureDecoder = func(*mapstructure.DecoderConfig) (*mapstructure.Decoder, error) {
+		return nil, errors.New("decoder setup failed")
+	}
+
+	err := &Error{
+		HTTPCode: 400,
+		Err:      errors.New("validation failed"),
+		Meta: struct {
+			Field string `json:"field"`
+		}{Field: "value"},
+	}
+
+	_, e := json.Marshal(err)
+	r.ErrorContains(e, "decoder setup failed")
+}
+
+func TestMarshalJSON_MapstructureDecodeError(t *testing.T) {
+	r := require.New(t)
+
+	err := &Error{
+		HTTPCode: 400,
+		Err:      errors.New("validation failed"),
+		Meta: struct {
+			//nolint:staticcheck // Intentionally exercises mapstructure's squash error path.
+			Invalid int `json:",squash"`
+		}{Invalid: 1},
+	}
+
+	_, e := json.Marshal(err)
+	r.ErrorContains(e, "cannot squash non-struct type")
 }

--- a/httperrors/errors_test.go
+++ b/httperrors/errors_test.go
@@ -455,6 +455,34 @@ func TestMarshalJSON_MetaPointerToStruct(t *testing.T) {
 	r.NotContains(obj, "meta")
 }
 
+func TestMarshalJSON_MetaPointerToPointerToStruct(t *testing.T) {
+	r := require.New(t)
+
+	type Details struct {
+		Field string `json:"field"`
+		Count int    `json:"count"`
+	}
+
+	details := &Details{Field: "value", Count: 3}
+
+	err := &Error{
+		HTTPCode: 400,
+		Err:      errors.New("validation failed"),
+		Code:     "TEST_CODE",
+		Meta:     &details,
+	}
+
+	data, e := json.Marshal(err)
+	r.NoError(e)
+
+	var obj map[string]any
+	r.NoError(json.Unmarshal(data, &obj))
+
+	r.Equal("value", obj["field"])
+	r.InDelta(3, obj["count"].(float64), 0.001)
+	r.NotContains(obj, "meta")
+}
+
 // TestMarshalJSON_ValueReceiver ensures that MarshalJSON is invoked when
 // Error is used as a value (e.g. in slices), not only through a pointer.
 func TestMarshalJSON_ValueReceiver(t *testing.T) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -32,7 +32,8 @@ func NewContext(ctx context.Context, reqID string) context.Context {
 
 var pid = uint32(time.Now().UnixNano() % 4294967291)
 
-// TraceID is the key for the x-request-id header.
+// TraceID is the HTTP header name used for trace correlation. It is not a
+// context key; use NewContext or WithContext to propagate trace IDs.
 var TraceID = "x-request-id"
 
 // DefaultGenRequestID default generate request id
@@ -89,16 +90,9 @@ func NewWithoutCaller(reqID ...string) Logger {
 
 // NewWithContext return logger with context
 func NewWithContext(ctx context.Context) Logger {
-	traceID := ""
-
-	if id, ok := ctx.Value(TraceID).(string); ok {
+	var traceID string
+	if id, ok := ctx.Value(TraceIDKey).(string); ok {
 		traceID = id
-	}
-
-	if traceID == "" {
-		if id, ok := ctx.Value(TraceIDKey).(string); ok {
-			traceID = id
-		}
 	}
 
 	log := newLogger(config, traceID)
@@ -277,32 +271,32 @@ func (l *Log) TraceID() string {
 
 // Debug debug level
 func Debug(arguments ...any) {
-	std.Debug(arguments)
+	std.Debug(arguments...)
 }
 
 // Info info level
 func Info(arguments ...any) {
-	std.Info(arguments)
+	std.Info(arguments...)
 }
 
 // Warn warn level
 func Warn(arguments ...any) {
-	std.Warn(arguments)
+	std.Warn(arguments...)
 }
 
 // Error error level
 func Error(arguments ...any) {
-	std.Error(arguments)
+	std.Error(arguments...)
 }
 
 // Fatal fatal level
 func Fatal(arguments ...any) {
-	std.Fatal(arguments)
+	std.Fatal(arguments...)
 }
 
 // Panic panic level
 func Panic(arguments ...any) {
-	std.Panic(arguments)
+	std.Panic(arguments...)
 }
 
 // Debugf debug format

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -53,12 +53,12 @@ func TestNewContext(t *testing.T) {
 }
 
 func TestNewWithContext(t *testing.T) {
-	t.Run("with TraceID", func(t *testing.T) {
-		//nolint:staticcheck // TraceID is a package-level constant used as context key
+	t.Run("ignores TraceID string context key", func(t *testing.T) {
+		//nolint:staticcheck // Verifies the deprecated string-key path is ignored.
 		ctx := context.WithValue(context.Background(), TraceID, "trace-123")
 		logger := NewWithContext(ctx)
 		assert.NotNil(t, logger)
-		assert.Equal(t, "trace-123", logger.TraceID())
+		assert.Empty(t, logger.TraceID())
 	})
 
 	t.Run("with TraceIDKey", func(t *testing.T) {
@@ -74,6 +74,87 @@ func TestNewWithContext(t *testing.T) {
 		assert.NotNil(t, logger)
 		assert.Empty(t, logger.TraceID())
 	})
+}
+
+type captureLogger struct {
+	last []any
+}
+
+func (l *captureLogger) capture(arguments ...any) {
+	l.last = append([]any(nil), arguments...)
+}
+
+func (l *captureLogger) Debug(arguments ...any) { l.capture(arguments...) }
+func (l *captureLogger) Info(arguments ...any)  { l.capture(arguments...) }
+func (l *captureLogger) Warn(arguments ...any)  { l.capture(arguments...) }
+func (l *captureLogger) Error(arguments ...any) { l.capture(arguments...) }
+func (l *captureLogger) Fatal(arguments ...any) { l.capture(arguments...) }
+func (l *captureLogger) Panic(arguments ...any) { l.capture(arguments...) }
+func (l *captureLogger) Debugf(format string, arguments ...any) {
+	l.capture(append([]any{format}, arguments...)...)
+}
+
+func (l *captureLogger) Infof(format string, arguments ...any) {
+	l.capture(append([]any{format}, arguments...)...)
+}
+
+func (l *captureLogger) Warnf(format string, arguments ...any) {
+	l.capture(append([]any{format}, arguments...)...)
+}
+
+func (l *captureLogger) Errorf(format string, arguments ...any) {
+	l.capture(append([]any{format}, arguments...)...)
+}
+
+func (l *captureLogger) Fatalf(format string, arguments ...any) {
+	l.capture(append([]any{format}, arguments...)...)
+}
+
+func (l *captureLogger) Panicf(format string, arguments ...any) {
+	l.capture(append([]any{format}, arguments...)...)
+}
+func (l *captureLogger) WithField(key string, value any) Logger  { return l }
+func (l *captureLogger) WithFields(fields map[string]any) Logger { return l }
+func (l *captureLogger) WithError(err error) Logger              { return l }
+func (l *captureLogger) SetLevel(level Level) Logger             { return l }
+func (l *captureLogger) Caller(frame int) Logger                 { return l }
+func (l *captureLogger) TraceID() string                         { return "" }
+func (l *captureLogger) WithContext(ctx ...context.Context) context.Context {
+	if len(ctx) > 0 {
+		return ctx[0]
+	}
+	return context.Background()
+}
+
+func TestPackageLevelVariadicFunctionsSpreadArguments(t *testing.T) {
+	oldStd := std
+	defer func() {
+		std = oldStd
+	}()
+
+	tests := []struct {
+		name string
+		log  func(...any)
+	}{
+		{name: "Debug", log: Debug},
+		{name: "Info", log: Info},
+		{name: "Warn", log: Warn},
+		{name: "Error", log: Error},
+		{name: "Fatal", log: Fatal},
+		{name: "Panic", log: Panic},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := &captureLogger{}
+			std = capture
+
+			tt.log("user", 42, "login")
+
+			require.Equal(t, []any{"user", 42, "login"}, capture.last)
+			require.NotEqual(t, []any{[]any{"user", 42, "login"}}, capture.last)
+		})
+	}
 }
 
 func TestDefaultGenRequestID(t *testing.T) {

--- a/render.go
+++ b/render.go
@@ -36,7 +36,6 @@ func (c *Context) renderError(err error) {
 		return
 	}
 
-	// TODO(m): render by writer content-type
 	if e, ok := err.(json.Marshaler); ok {
 		c.JSON(code, e)
 	} else {
@@ -60,7 +59,6 @@ func (c *Context) render(res any) {
 	case render.Render:
 		c.Render(http.StatusOK, r)
 	default:
-		// TODO(m): render by writer content-type
 		c.JSON(http.StatusOK, r)
 	}
 

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -1,0 +1,18 @@
+package render_test
+
+import (
+	"testing"
+
+	foxrender "github.com/fox-gonic/fox/render"
+	ginrender "github.com/gin-gonic/gin/render"
+)
+
+func TestRenderAliases(t *testing.T) {
+	var _ foxrender.Render = ginrender.JSON{}
+
+	acceptJSON := func(ginrender.JSON) {}
+	acceptRedirect := func(ginrender.Redirect) {}
+
+	acceptJSON(foxrender.JSON{Data: "x"})
+	acceptRedirect(foxrender.Redirect{Code: 302, Location: "/"})
+}

--- a/render_test.go
+++ b/render_test.go
@@ -525,6 +525,23 @@ func TestRender_Pointer(t *testing.T) {
 	assert.True(t, ctx.IsAborted())
 }
 
+func TestRender_ReturningMiddlewareAbortsChain(t *testing.T) {
+	engine := New()
+	engine.Use(func(c *Context) string {
+		return "stopped"
+	})
+	engine.GET("/next", func(c *Context) string {
+		return "next"
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/next", nil)
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "stopped", w.Body.String())
+}
+
 // Benchmark tests
 
 func BenchmarkRenderError_Plain(b *testing.B) {

--- a/response_time.go
+++ b/response_time.go
@@ -18,7 +18,7 @@ type XResponseTimer struct {
 
 // WriteHeader implement http.ResponseWriter
 func (w *XResponseTimer) WriteHeader(statusCode int) {
-	buf := make([]byte, 0, 32)
+	buf := make([]byte, 0, 40)
 	buf = strconv.AppendInt(buf, w.start.UnixMilli(), 10)
 	buf = append(buf, ',', ' ')
 	buf = strconv.AppendInt(buf, time.Since(w.start).Nanoseconds(), 10)

--- a/response_time.go
+++ b/response_time.go
@@ -1,7 +1,7 @@
 package fox
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -18,7 +18,11 @@ type XResponseTimer struct {
 
 // WriteHeader implement http.ResponseWriter
 func (w *XResponseTimer) WriteHeader(statusCode int) {
-	w.Header().Set(w.key, fmt.Sprintf("%d, %d", w.start.UnixMilli(), time.Since(w.start).Nanoseconds()))
+	buf := make([]byte, 0, 32)
+	buf = strconv.AppendInt(buf, w.start.UnixMilli(), 10)
+	buf = append(buf, ',', ' ')
+	buf = strconv.AppendInt(buf, time.Since(w.start).Nanoseconds(), 10)
+	w.Header().Set(w.key, string(buf))
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 

--- a/route_registry.go
+++ b/route_registry.go
@@ -23,6 +23,10 @@ type RouteInfo struct {
 }
 
 func (engine *Engine) registerHandlerRoute(method, path string, handlers HandlersChain) {
+	if engine.handlerRoutesDisabled.Load() {
+		return
+	}
+
 	handler := handlers.Last()
 	if handler == nil {
 		return
@@ -39,7 +43,7 @@ func (engine *Engine) registerHandlerRoute(method, path string, handlers Handler
 	engine.handlerRoutesMu.Lock()
 	defer engine.handlerRoutesMu.Unlock()
 
-	if engine.handlerRoutesDisabled {
+	if engine.handlerRoutesDisabled.Load() {
 		return
 	}
 

--- a/route_registry_test.go
+++ b/route_registry_test.go
@@ -50,3 +50,15 @@ func TestRegisterHandlerRouteIgnoresEmptyHandlerChain(t *testing.T) {
 	engine.registerHandlerRoute("GET", "/empty", nil)
 	require.Empty(t, engine.HandlerRoutes())
 }
+
+func BenchmarkRegisterHandlerRoute_Disabled(b *testing.B) {
+	engine := New()
+	engine.DisableRouteRegistry()
+	handlers := HandlersChain{registeredRouteHandler}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		engine.registerHandlerRoute("GET", "/x", handlers)
+	}
+}

--- a/routergroup.go
+++ b/routergroup.go
@@ -30,7 +30,7 @@ func (group *RouterGroup) handleWrapper(handlers ...HandlerFunc) gin.HandlersCha
 
 	for _, handler := range handlers {
 		if !IsValidHandlerFunc(handler) {
-			panic(fmt.Sprintf(ErrInvalidHandlerType, reflect.TypeOf(handler).String(), utils.NameOfFunction(handler)))
+			panic(fmt.Sprintf(MsgInvalidHandlerType, reflect.TypeOf(handler).String(), utils.NameOfFunction(handler)))
 		}
 
 		f := func(h HandlerFunc) gin.HandlerFunc {

--- a/validator.go
+++ b/validator.go
@@ -8,7 +8,9 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-// Validate global validator
+// Validate is the global validator instance used by Fox's DefaultValidator.
+// Register custom validations on this instance before request handling begins,
+// for example in init() or main().
 var Validate = validator.New()
 
 // DefaultValidator is the default implementation of Validator.
@@ -41,9 +43,7 @@ func (v *DefaultValidator) Engine() any {
 
 func (v *DefaultValidator) lazyinit() {
 	v.once.Do(func() {
-		v.validate = validator.New()
-
-		// add any custom validations etc. here
+		v.validate = Validate
 	})
 }
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -263,10 +263,26 @@ func TestDefaultValidator_Engine(t *testing.T) {
 	validate, ok := engine.(*validator.Validate)
 	assert.True(t, ok)
 	assert.NotNil(t, validate)
+	assert.Same(t, Validate, validate)
 
 	// Calling Engine multiple times should return the same instance
 	engine2 := v.Engine()
 	assert.Same(t, engine, engine2)
+}
+
+func TestDefaultValidator_UsesGlobalValidate(t *testing.T) {
+	const tag = "global_foo"
+
+	require.NoError(t, Validate.RegisterValidation(tag, func(fl validator.FieldLevel) bool {
+		return fl.Field().String() == "foo"
+	}))
+
+	type request struct {
+		Value string `validate:"global_foo"`
+	}
+
+	err := (&DefaultValidator{}).ValidateStruct(request{Value: "bar"})
+	require.Error(t, err)
 }
 
 func TestDefaultValidator_LazyInit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix runtime behavior found by the May 2026 audit: package-level logger calls now forward variadic arguments, binding preserves `httperrors.Error`, pointer request structs run `IsValider`, request bodies are skipped when absent, and trace/route-registry/response-time behavior is tightened.
- Bring docs and examples back in sync with the public API: `httperrors.Error` fields, JSON error responses, middleware abort semantics, domain matching order, supported versions, changelog notes, and benchmark reproduction guidance.
- Add regression coverage for the audited paths, including render helpers, all example apps, validator/default-validator behavior, logger context handling, route registry toggles, and Gin comparison benchmarks.

## ⚠️ Breaking Changes
These are minor breaking changes acceptable under the `0.0.x` track; consumers upgrading should adjust as noted:

1. **`IsValidHandlerFunc` rejects `interface` as the second parameter type.** Handlers written as `func(ctx, args any) ...` will panic at registration with `invalid handler type`. Replace `any` / `interface{}` with a concrete `struct` or `map` type.
2. **`logger.NewWithContext` stops reading `logger.TraceID` (string) context keys.** Code using `context.WithValue(parent, logger.TraceID, id)` will silently produce empty trace IDs. Switch to the typed key `logger.TraceIDKey`, or use `logger.NewContext(ctx, id)`.
3. **`*httperrors.Error` from `IsValid()` is no longer wrapped as `BIND_ERROR`.** Responses now carry the user-defined `Code` and `HTTPCode`. Clients that matched the `BIND_ERROR` string to detect validation failures should switch to the HTTP 400 status or a specific code list. Detection uses `errors.As`, so `fmt.Errorf("...: %w", httpErr)` wrappers are also unwrapped.

Additional deprecation: `ErrInvalidHandlerType` is kept as an alias of `MsgInvalidHandlerType` and will be removed in `v0.1.0`.

## Notable Changes
- `httperrors.Error.MarshalJSON` no longer mutates its receiver (uses a local `meta`) and now flattens both value-struct and pointer-to-struct `Meta` via `reflect.Indirect`. The receiver remains a value so `[]Error` / `map[string]Error` still marshal correctly.
- `bind` short-circuits body reads only when `Content-Length == 0` **and** no transfer encoding is declared. Unknown-length (`-1`) and chunked requests continue to read as before.
- `DefaultValidator` now reuses the package-level `Validate` instance, so custom validations registered via `fox.Validate.RegisterValidation(...)` are honored during binding.
- Example router setup uses testable `newRouter()` helpers; the basic example handler signature is corrected.
- Content-negotiation TODOs in `render.go` are removed and tracked in #65.

## Test Plan
- `PATH="$(go env GOPATH)/bin:$PATH" GOFLAGS=-buildvcs=false make check`
- `go test ./... -race -count=2`
- `make benchmark`

`GOFLAGS=-buildvcs=false` was only needed for this local worktree because Go VCS stamping failed for example packages outside the main checkout metadata.