### PR TITLE
feat: add route manifest export

### DIFF
--- a/route_manifest.go
+++ b/route_manifest.go
@@ -1,0 +1,206 @@
+package fox
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+var (
+	routeManifestContextType = reflect.TypeOf(Context{})
+	routeManifestErrorType   = reflect.TypeOf((*error)(nil)).Elem()
+)
+
+// RouteManifestVersion is the current JSON route manifest format version.
+const RouteManifestVersion = "fox.route-manifest/v1"
+
+// RouteManifest is a stable JSON representation of routes registered on an
+// Engine. Tooling can consume it without booting the application itself.
+type RouteManifest struct {
+	Version string               `json:"version"`
+	Routes  []RouteManifestRoute `json:"routes"`
+}
+
+// RouteManifestRoute describes one Fox route and the original business handler
+// captured at registration time.
+type RouteManifestRoute struct {
+	Method      string              `json:"method"`
+	Path        string              `json:"path"`
+	Handler     string              `json:"handler,omitempty"`
+	InputTypes  []RouteManifestType `json:"inputTypes,omitempty"`
+	ResultTypes []RouteManifestType `json:"resultTypes,omitempty"`
+}
+
+// RouteManifestType is a serializable subset of reflect.Type.
+type RouteManifestType struct {
+	Kind    string               `json:"kind"`
+	Name    string               `json:"name,omitempty"`
+	PkgPath string               `json:"pkgPath,omitempty"`
+	Key     *RouteManifestType   `json:"key,omitempty"`
+	Elem    *RouteManifestType   `json:"elem,omitempty"`
+	Fields  []RouteManifestField `json:"fields,omitempty"`
+}
+
+// RouteManifestField is a serializable subset of reflect.StructField.
+type RouteManifestField struct {
+	Name      string            `json:"name"`
+	Tag       string            `json:"tag,omitempty"`
+	Anonymous bool              `json:"anonymous,omitempty"`
+	Type      RouteManifestType `json:"type"`
+}
+
+// RouteManifestFromEngine returns a serializable snapshot of the Engine route
+// registry.
+func RouteManifestFromEngine(engine *Engine) RouteManifest {
+	manifest := RouteManifest{Version: RouteManifestVersion}
+	if engine == nil {
+		return manifest
+	}
+	for _, route := range engine.HandlerRoutes() {
+		manifest.Routes = append(manifest.Routes, routeManifestRoute(route))
+	}
+	return manifest
+}
+
+// WriteRouteManifest writes the Engine route registry as indented JSON.
+func WriteRouteManifest(engine *Engine, path string) error {
+	if path == "" {
+		return errors.New("route manifest path is required")
+	}
+	data, err := json.MarshalIndent(RouteManifestFromEngine(engine), "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal route manifest: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create route manifest dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write route manifest: %w", err)
+	}
+	return nil
+}
+
+func routeManifestRoute(route RouteInfo) RouteManifestRoute {
+	result := RouteManifestRoute{
+		Method:  route.Method,
+		Path:    route.Path,
+		Handler: route.HandlerName,
+	}
+	if route.HandlerType == nil {
+		return result
+	}
+	if !routeManifestNeedsInlineTypes(route.HandlerName) {
+		return result
+	}
+	result.InputTypes = manifestTypeList(route.HandlerType, true, map[reflect.Type]bool{})
+	result.ResultTypes = manifestTypeList(route.HandlerType, false, map[reflect.Type]bool{})
+	return result
+}
+
+func routeManifestNeedsInlineTypes(handlerName string) bool {
+	return strings.Contains(handlerName, ".func")
+}
+
+func manifestTypeList(typ reflect.Type, inputs bool, seen map[reflect.Type]bool) []RouteManifestType {
+	var count int
+	if inputs {
+		count = typ.NumIn()
+	} else {
+		count = typ.NumOut()
+	}
+	result := make([]RouteManifestType, 0, count)
+	for i := 0; i < count; i++ {
+		if inputs {
+			input := typ.In(i)
+			if routeManifestIsFoxContext(input) {
+				continue
+			}
+			result = append(result, routeManifestType(input, seen))
+		} else {
+			result = append(result, routeManifestType(typ.Out(i), seen))
+		}
+	}
+	return result
+}
+
+func routeManifestType(typ reflect.Type, seen map[reflect.Type]bool) RouteManifestType {
+	if typ == nil {
+		return RouteManifestType{}
+	}
+	result := RouteManifestType{
+		Kind:    typ.Kind().String(),
+		Name:    typ.Name(),
+		PkgPath: typ.PkgPath(),
+	}
+	if routeManifestIsConcreteError(typ) {
+		return RouteManifestType{Kind: "string", Name: "string"}
+	}
+	// Anonymous composite types cannot form recursive cycles without a named
+	// type, so keep their structure instead of emitting empty []T/map shells.
+	if seen[typ] && typ.Name() != "" {
+		return result
+	}
+	if routeManifestOpaqueType(typ) {
+		return result
+	}
+	seen[typ] = true
+
+	switch typ.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Array:
+		elem := routeManifestType(typ.Elem(), seen)
+		result.Elem = &elem
+	case reflect.Map:
+		key := routeManifestType(typ.Key(), seen)
+		elem := routeManifestType(typ.Elem(), seen)
+		result.Key = &key
+		result.Elem = &elem
+	case reflect.Struct:
+		result.Fields = make([]RouteManifestField, 0, typ.NumField())
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			if field.PkgPath != "" {
+				continue
+			}
+			result.Fields = append(result.Fields, RouteManifestField{
+				Name:      field.Name,
+				Tag:       string(field.Tag),
+				Anonymous: field.Anonymous,
+				Type:      routeManifestType(field.Type, seen),
+			})
+		}
+	}
+	return result
+}
+
+func routeManifestIsConcreteError(typ reflect.Type) bool {
+	if typ == nil || typ == routeManifestErrorType {
+		return false
+	}
+	if typ.Implements(routeManifestErrorType) {
+		return true
+	}
+	if typ.Kind() != reflect.Pointer && reflect.PointerTo(typ).Implements(routeManifestErrorType) {
+		return true
+	}
+	return false
+}
+
+func routeManifestIsFoxContext(typ reflect.Type) bool {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	return typ == routeManifestContextType
+}
+
+func routeManifestOpaqueType(typ reflect.Type) bool {
+	switch typ.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Array:
+		return false
+	}
+	return typ.PkgPath() == "time"
+}

--- a/route_registry_test.go
+++ b/route_registry_test.go
@@ -1,14 +1,69 @@
 package fox
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func registeredRouteHandler(_ *Context) string {
 	return "ok"
+}
+
+type manifestUserRequest struct {
+	ID     string `uri:"id" binding:"required"`
+	Search string `query:"search"`
+}
+
+type manifestUserResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type manifestNestedType struct {
+	When time.Time `json:"when"`
+}
+
+type manifestCustomError struct {
+	Code string `json:"code"`
+}
+
+func (err manifestCustomError) Error() string {
+	return err.Code
+}
+
+type manifestComplexType struct {
+	Items  []manifestNestedType           `json:"items"`
+	Lookup map[string]*manifestNestedType `json:"lookup"`
+	Self   *manifestComplexType           `json:"self"`
+	Err    manifestCustomError            `json:"err"`
+	hidden string
+}
+
+type manifestRepeatedCompositeType struct {
+	First  []manifestNestedType `json:"first"`
+	Second []manifestNestedType `json:"second"`
+}
+
+func manifestUserHandler(_ *Context, _ manifestUserRequest) (manifestUserResponse, error) {
+	return manifestUserResponse{}, nil
+}
+
+func manifestClosureHandler() HandlerFunc {
+	return func(_ *Context, _ manifestUserRequest) (manifestUserResponse, error) {
+		return manifestUserResponse{}, nil
+	}
+}
+
+func manifestSharedTypeClosureHandler() HandlerFunc {
+	return func(_ *Context, _ manifestNestedType) (manifestNestedType, error) {
+		return manifestNestedType{}, nil
+	}
 }
 
 func TestHandlerRoutesReturnsOriginalHandlerMetadata(t *testing.T) {
@@ -49,6 +104,177 @@ func TestRegisterHandlerRouteIgnoresEmptyHandlerChain(t *testing.T) {
 	engine := New()
 	engine.registerHandlerRoute("GET", "/empty", nil)
 	require.Empty(t, engine.HandlerRoutes())
+}
+
+func TestWriteRouteManifest(t *testing.T) {
+	engine := New()
+	engine.GET("/users/:id", manifestUserHandler)
+
+	path := filepath.Join(t.TempDir(), "api", "routes.manifest.json")
+	require.NoError(t, WriteRouteManifest(engine, path))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var manifest RouteManifest
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	require.Equal(t, RouteManifestVersion, manifest.Version)
+	require.Len(t, manifest.Routes, 1)
+	require.Equal(t, "GET", manifest.Routes[0].Method)
+	require.Equal(t, "/users/:id", manifest.Routes[0].Path)
+	require.Contains(t, manifest.Routes[0].Handler, "manifestUserHandler")
+	require.Empty(t, manifest.Routes[0].InputTypes)
+	require.Empty(t, manifest.Routes[0].ResultTypes)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	routes := raw["routes"].([]any)
+	route := routes[0].(map[string]any)
+	require.Contains(t, route, "handler")
+	require.NotContains(t, route, "handlerName")
+	require.NotContains(t, route, "handlerType")
+	require.NotContains(t, route, "inputs")
+	require.NotContains(t, route, "results")
+}
+
+func TestWriteRouteManifestRejectsEmptyPath(t *testing.T) {
+	require.EqualError(t, WriteRouteManifest(New(), ""), "route manifest path is required")
+}
+
+func TestWriteRouteManifestReportsWriteErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "routes.manifest.json")
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	err := WriteRouteManifest(New(), path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "write route manifest")
+}
+
+func TestWriteRouteManifestReportsCreateDirErrors(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "api")
+	require.NoError(t, os.WriteFile(filePath, []byte("not a directory"), 0o644))
+
+	err := WriteRouteManifest(New(), filepath.Join(filePath, "routes.manifest.json"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "create route manifest dir")
+}
+
+func TestRouteManifestFromNilEngine(t *testing.T) {
+	manifest := RouteManifestFromEngine(nil)
+	require.Equal(t, RouteManifestVersion, manifest.Version)
+	require.Empty(t, manifest.Routes)
+}
+
+func TestWriteRouteManifestKeepsClosureTypes(t *testing.T) {
+	engine := New()
+	engine.GET("/users/:id", manifestClosureHandler())
+
+	manifest := RouteManifestFromEngine(engine)
+	require.Len(t, manifest.Routes, 1)
+	require.Contains(t, manifest.Routes[0].Handler, ".func")
+	require.Len(t, manifest.Routes[0].InputTypes, 1)
+	require.Equal(t, "manifestUserRequest", manifest.Routes[0].InputTypes[0].Name)
+	require.Len(t, manifest.Routes[0].ResultTypes, 2)
+	require.Equal(t, "manifestUserResponse", manifest.Routes[0].ResultTypes[0].Name)
+}
+
+func TestWriteRouteManifestExpandsClosureInputsAndResultsIndependently(t *testing.T) {
+	engine := New()
+	engine.GET("/nested", manifestSharedTypeClosureHandler())
+
+	manifest := RouteManifestFromEngine(engine)
+	require.Len(t, manifest.Routes, 1)
+	require.Len(t, manifest.Routes[0].InputTypes, 1)
+	require.Len(t, manifest.Routes[0].ResultTypes, 2)
+	require.Len(t, manifest.Routes[0].InputTypes[0].Fields, 1)
+	require.Equal(t, "manifestNestedType", manifest.Routes[0].ResultTypes[0].Name)
+	require.Len(t, manifest.Routes[0].ResultTypes[0].Fields, 1)
+}
+
+func TestRouteManifestTypeSerializesComplexTypes(t *testing.T) {
+	require.Empty(t, manifestComplexType{}.hidden)
+
+	typ := routeManifestType(reflect.TypeOf(manifestComplexType{}), map[reflect.Type]bool{})
+
+	require.Equal(t, "struct", typ.Kind)
+	require.Equal(t, "manifestComplexType", typ.Name)
+	require.Len(t, typ.Fields, 4)
+
+	items := typ.Fields[0]
+	require.Equal(t, "Items", items.Name)
+	require.Equal(t, "slice", items.Type.Kind)
+	require.NotNil(t, items.Type.Elem)
+	require.Equal(t, "manifestNestedType", items.Type.Elem.Name)
+	require.Len(t, items.Type.Elem.Fields, 1)
+	require.Equal(t, "Time", items.Type.Elem.Fields[0].Type.Name)
+	require.Empty(t, items.Type.Elem.Fields[0].Type.Fields)
+
+	lookup := typ.Fields[1]
+	require.Equal(t, "Lookup", lookup.Name)
+	require.Equal(t, "map", lookup.Type.Kind)
+	require.NotNil(t, lookup.Type.Key)
+	require.NotNil(t, lookup.Type.Elem)
+	require.Equal(t, "string", lookup.Type.Key.Kind)
+	require.Equal(t, "ptr", lookup.Type.Elem.Kind)
+	require.Equal(t, "manifestNestedType", lookup.Type.Elem.Elem.Name)
+
+	self := typ.Fields[2]
+	require.Equal(t, "Self", self.Name)
+	require.Equal(t, "ptr", self.Type.Kind)
+	require.Equal(t, "manifestComplexType", self.Type.Elem.Name)
+	require.Empty(t, self.Type.Elem.Fields)
+
+	errField := typ.Fields[3]
+	require.Equal(t, "Err", errField.Name)
+	require.Equal(t, "string", errField.Type.Kind)
+	require.Equal(t, "string", errField.Type.Name)
+}
+
+func TestRouteManifestTypeKeepsRepeatedUnnamedCompositeStructure(t *testing.T) {
+	typ := routeManifestType(reflect.TypeOf(manifestRepeatedCompositeType{}), map[reflect.Type]bool{})
+
+	require.Len(t, typ.Fields, 2)
+	for _, field := range typ.Fields {
+		require.Equal(t, "slice", field.Type.Kind)
+		require.NotNil(t, field.Type.Elem)
+		require.Equal(t, "manifestNestedType", field.Type.Elem.Name)
+	}
+}
+
+func TestRouteManifestTypeHandlesNil(t *testing.T) {
+	require.Empty(t, routeManifestType(nil, map[reflect.Type]bool{}))
+}
+
+func TestRouteManifestTypePreservesErrorInterfaceResult(t *testing.T) {
+	typ := routeManifestType(reflect.TypeOf((*error)(nil)).Elem(), map[reflect.Type]bool{})
+	require.Equal(t, "interface", typ.Kind)
+	require.Equal(t, "error", typ.Name)
+}
+
+func TestRouteManifestIsFoxContextUsesContextType(t *testing.T) {
+	require.True(t, routeManifestIsFoxContext(reflect.TypeOf(&Context{})))
+	require.True(t, routeManifestIsFoxContext(reflect.TypeOf(Context{})))
+	require.False(t, routeManifestIsFoxContext(reflect.TypeOf(struct {
+		Context Context
+	}{})))
+}
+
+func TestRouteManifestTypeSerializesConcreteErrorsAsStrings(t *testing.T) {
+	typ := routeManifestType(reflect.TypeOf(manifestCustomError{}), map[reflect.Type]bool{})
+	require.Equal(t, "string", typ.Kind)
+	require.Equal(t, "string", typ.Name)
+	require.Empty(t, typ.Fields)
+}
+
+func TestRouteManifestRouteWithoutHandlerType(t *testing.T) {
+	route := routeManifestRoute(RouteInfo{Method: "GET", Path: "/raw", HandlerName: "raw.func1"})
+	require.Equal(t, "GET", route.Method)
+	require.Equal(t, "/raw", route.Path)
+	require.Equal(t, "raw.func1", route.Handler)
+	require.Empty(t, route.InputTypes)
+	require.Empty(t, route.ResultTypes)
 }
 
 func BenchmarkRegisterHandlerRoute_Disabled(b *testing.B) {


### PR DESCRIPTION
## Summary

Adds a compact route manifest export API for Fox applications so downstream tooling can read registered routes without requiring business projects to build a special OpenAPI-only engine.

## Changes

- Add `RouteManifestFromEngine` and `WriteRouteManifest`.
- Export route `method`, `path`, and `handler` for normal handlers.
- Include inline input/result type details only for closure handlers, where source-based tooling cannot reliably resolve a stable handler symbol.
- Cover manifest writing and closure fallback behavior in route registry tests.

## Verification

- `go test ./...`
- `golangci-lint run --verbose`
