### PR TITLE
docs(changelog): drop content negotiation from roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ may need to adapt to breaking changes between minor versions until `v1.0.0`.
 - lumberjack dependency uses +incompatible version
 
 ### Upcoming Features
-- Built-in security middleware (rate limiting, CSRF, request-size limits)
+- Built-in security middleware (rate limiting, CSRF, request size limits)
 - Additional middleware for common use cases
 - Improved documentation and examples
 - Performance optimizations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,15 +175,13 @@ migration note. Production use is possible with the understanding that you
 may need to adapt to breaking changes between minor versions until `v1.0.0`.
 
 ### Known Issues
-- Content negotiation by `Accept` header is pending — tracked in [#65](https://github.com/fox-gonic/fox/issues/65).
 - lumberjack dependency uses +incompatible version
 
 ### Upcoming Features
-- Enhanced content negotiation based on Accept headers
+- Built-in security middleware (rate limiting, CSRF, request-size limits)
 - Additional middleware for common use cases
 - Improved documentation and examples
 - Performance optimizations
-- Security enhancements (rate limiting, request size limits)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Issue #65 (content negotiation by Accept header) was just closed as deferred / not planned — JSON-only behavior in \`render.go\` is the intended default, not pending work.

This PR removes the now-stale references to it from CHANGELOG:

- **Known Issues**: drop the \"#65 pending\" line.
- **Upcoming Features**: drop \"Enhanced content negotiation\" and consolidate the security work that SECURITY.md already commits to (rate limit / CSRF / request-size limits) into one explicit bullet, instead of two vaguely overlapping ones.

No code changes. No CHANGELOG version section is touched (the closed issue post-dates the v0.1.0 cut).

## Test plan

- [x] \`grep '#65' CHANGELOG.md\` returns nothing
- [ ] Reviewer agrees with the deferral framing