### PR TITLE
ci: pin Go toolchain to 1.25.10

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.25.10"
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.25.x"]
+        go: ["1.25.10"]
         include:
           - os: ubuntu-latest
             go-build: ~/.cache/go-build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.25.10"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.25.10"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary

Today's Go release published 5 stdlib advisories — `GO-2026-4977` (quadratic concat in `net/mail`), `GO-2026-4971` (Windows `net.Dial` panic), `GO-2026-4980` (html/template escaper bypass), and 2 more — all fixed in **Go 1.25.10**. Both workflows previously specified `1.25.x`, which was still resolving to **1.25.9** when the most recent runs landed, so `govulncheck` started failing across main and every open PR.

This PR pins both `Run Tests` (lint + matrix) and `Security Scanning` (govulncheck + CodeQL) to `"1.25.10"` explicitly. Once setup-go's catalog is fully updated and we want the looser `.x` semantics back we can flip it, but for now an explicit pin is the cheapest way to make the security gate deterministic.

`go.mod` still declares `go 1.25.0` — that is the module's minimum Go version and is intentionally not changed (bumping it would be a breaking change for downstream consumers).

## Test plan

- [ ] `Go Vulnerability Check` turns green on this PR
- [ ] All other checks remain green
- [ ] After merge, main CI is green again